### PR TITLE
OSC分配モジュールduplicator.pyの追加とtest_duplicator.pyの整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           pip install -r requirements.txt
           pip install flake8
       - name: Run Flake8
-        run: flake8
+        run: flake8 --max-line-length 88
 
   tests:
     runs-on: windows-latest

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -1,0 +1,203 @@
+import json
+import queue
+from dataclasses import dataclass
+from threading import Thread
+from typing import Optional
+
+from pythonosc import dispatcher, osc_server, udp_client
+
+
+@dataclass
+class TransmitPortSetting:
+    """
+    再送信先のポートのデータを保持する
+
+    Parameters
+    ---------
+    name: str
+        ポートの名称
+    port: int
+        ポート番号
+    enable: bool
+        そのポートに再送信するかどうか
+    """
+
+    name: str
+    port: int
+    enabled: bool
+
+    def __post_init__(self):
+        # Validate the 'name' attribute
+        if not isinstance(self.name, str):
+            raise TypeError(
+                "Expected instance of type 'str' for attribute 'name',"
+                f"but got '{type(self.name).__name__}'."
+            )
+
+        # Validate the 'port' attribute
+        if not isinstance(self.port, int):
+            raise TypeError(
+                "Expected instance of type 'int' for attribute 'port',"
+                f" but got '{type(self.port).__name__}'."
+            )
+        if not (0 <= self.port <= 65535):  # standard port range for TCP/UDP
+            raise ValueError(
+                "Invalid 'port' value. Expected a number between 0 and 65535, "
+                f"but got '{self.port}'."
+            )
+
+        # Validate the 'enabled' attribute
+        if not isinstance(self.enabled, bool):
+            raise TypeError(
+                "Expected instance of type 'bool' for attribute 'enabled',"
+                f" but got '{type(self.enabled).__name__}'."
+            )
+
+
+class OSCDuplicator:
+    """
+    OSC信号を受信するためのサーバーと、再送信のための設定を保持する
+
+    Attributes
+    ---------
+    server: osc_server.ThreadingOSCUDPServer
+        OSC信号を受信するためのサーバー
+    receive_port: int
+        OSC信号を受信するためのポート、デフォルト9001
+    transmit_port_settings: list[TransmitPortSetting]
+        転送先ポートの設定を保持するリスト
+    clients: list[udp_client.SimpleUDPClient]
+        OSC信号を再送信するための、clientのリスト
+    q: queue.Queue
+        OSC信号の受信順・送信順を保証するためのキュー
+    """
+
+    def __init__(self) -> None:
+        self.__receive_port: Optional[int] = None
+        self.__transmit_port_settings: list[TransmitPortSetting] = []
+        self.__server: Optional[osc_server.ThreadingOSCUDPServer] = None
+        self.__clients: list[udp_client.SimpleUDPClient] = []
+        self.__q = queue.Queue()
+
+    @property
+    def receive_port(self):
+        return self.__receive_port
+
+    @receive_port.setter
+    def receive_port(self, value: int):
+        """
+        __receiver_portのsetter
+        値のチェックをする
+
+        Parameters
+        ---------
+        value: int
+            新しい受信ポート番号
+        """
+        # check value
+        if not isinstance(value, int):
+            raise TypeError("Expected instance of type 'int' for attribute 'port'")
+        if not (0 <= value <= 65535):  # standard port range for TCP/UDP
+            raise ValueError(
+                "Invalid 'port' value. Expected a number between 0 and 65535"
+            )
+        self.__receive_port = value
+
+    def start_server(self) -> None:
+        """
+        OSCサーバーを初期化し、起動する
+        """
+        port = self.receive_port if self.receive_port is not None else 9001
+        dpt = dispatcher.Dispatcher()
+
+        dpt.map("/*", self.__queue_osc)
+
+        self.__server = osc_server.ThreadingOSCUDPServer(("127.0.0.1", port), dpt)
+        self.__server.serve_forever()
+
+    def stop_server(self) -> None:
+        """
+        OSCサーバーを終了する
+        """
+        self.__server.shutdown()
+
+    def __queue_osc(self, q: queue.Queue, address: str, *args: list) -> None:
+        """
+        受信したOSC信号をdictとして、キューに追加する
+
+        Parameters
+        ---------
+        address: str
+            受信・再送信アドレス
+        args: list
+            osc信号
+        """
+        d = {"address": address, "args": args}
+        q.put(d)
+
+    def transmit_msg(
+        self, transmit_clients: list[udp_client.SimpleUDPClient], q: queue.Queue
+    ) -> None:
+        """
+        osc信号を転送する
+
+        Parameters
+        ---------
+        transmit_clients: list[udp_client.SimpleUDPClient]
+            OSC信号を再送信するための、clientのリスト
+        q: queue.Queue
+            キュー
+            {"address": address, "args": args}
+        """
+
+        if len(transmit_clients) <= 0:
+            return
+
+        while True:
+            d = q.get()
+            address: str = d["address"]
+            args: list = d["args"]
+
+            threads = [
+                Thread(target=client.send_message, args=(address, args))
+                for client in transmit_clients
+            ]
+
+            for thread in threads:
+                thread.start()
+
+            for thread in threads:
+                thread.join()
+
+            q.task_done()
+
+    def load_settings(self, file_path: str):
+        self.receive_port, self.transmit_list = self.__load_json(file_path)
+
+    def __load_json(self, file_path: str):
+        """
+        jsonファイルから設定データを呼び出し
+
+        Parameters
+        ---------
+        file_path: str
+            設定ファイルのパス
+
+        Returns
+        ---------
+        receive_port: int
+            受信ポート
+        transmit_list: list[TransmitPortSettings]
+            分配ポートのセッティング(dataclass)のリスト
+        """
+
+        with open(file_path, "r", encoding="UTF-8") as f:
+            json_dic = json.load(f)
+
+        receive_port = json_dic["receive"]
+
+        transmit_list: list[TransmitPortSetting] = [
+            TransmitPortSetting(**i) for i in json_dic["transmit"]
+        ]
+
+        return receive_port, transmit_list

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -1,0 +1,98 @@
+from threading import Thread
+from time import sleep
+
+import pytest
+from pythonosc import osc_server
+
+from oscduplicator.duplicator import OSCDuplicator, TransmitPortSetting
+
+
+class TestTransmitPortSettings:
+    def test_init_TransmitPortSettings(self):
+        """
+        TransmitPortSettingが不正な値に対して例外を出せるかテスト
+        """
+
+        # correct data
+        port_settings = TransmitPortSetting("Port0", 9000, True)
+        assert port_settings.name == "Port0"
+        assert port_settings.port == 9000
+        assert port_settings.enabled is True
+
+        # incorrect data type
+        with pytest.raises(TypeError):
+            TransmitPortSetting(123, 9000, False)
+
+        with pytest.raises(TypeError):
+            TransmitPortSetting("設定", "9000", True)
+
+        # incorrect data value
+        with pytest.raises(ValueError):
+            TransmitPortSetting("koya_so", -1, True)
+
+        with pytest.raises(ValueError):
+            TransmitPortSetting("koya_so", 65536, True)
+
+        with pytest.raises(TypeError):
+            TransmitPortSetting("nyanko", 8000, "neko")
+
+
+class TestDuplicator:
+    osc_duplicator = OSCDuplicator()
+    # def test_start_server(self):
+    #     """
+    #     サーバーを起動できるかテスト
+    #     """
+    #     pass
+
+    def test_start_stop_server(self):
+        """
+        サーバーを起動・停止できるかテスト
+        """
+
+        def __server_is_shut_down(server: osc_server.ThreadingOSCUDPServer):
+            """
+            サーバーがシャットダウンしているかどうか判定する
+            """
+            return server._BaseServer__is_shut_down.is_set()
+
+        assert self.osc_duplicator.receive_port is None
+
+        self.osc_duplicator.receive_port = 9001
+
+        assert self.osc_duplicator.receive_port == 9001
+
+        th = Thread(target=self.osc_duplicator.start_server, daemon=True)
+        th.start()
+
+        sleep(1)
+        assert (
+            __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server) is False
+        )
+        self.osc_duplicator.stop_server()
+        sleep(1)
+        assert __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server) is True
+
+    def test_load_settings(self):
+        """
+        正しくjsonファイルを読み込めるかテスト
+        """
+        pass
+
+    def test_update_settings(self):
+        """
+        class Duplicatorの設定を書き換えれるかテスト
+        """
+        pass
+
+    def test_save_settings(self):
+        """
+        正しくjsonファイルを書き出せるかテスト
+        """
+        pass
+
+    def test_transmit_msg(self):
+        """
+        キューからOSC信号を取り出し、転送できるかテストする
+        """
+        pass


### PR DESCRIPTION
1. 自分の開発環境ではコードをblackで整形しようと考えています。flake8は1行当たり79文字がデフォルトですが、blackは88文字がデフォルトのようです。調べてみたところ、flale8にオプション`--max-line-length 88`を追加する方法が標準のようなので、git actionsのflake8の実行コマンドにオプションを追加しました。

2. oscを分配するモジュールduplicator.pyを作成しました。`__init__()`, `receive_port()`, `start_server()`, `stop_server()`はとりあえず完成しています。それ以外のメソッドはテストを作成中で、明日以降に大きく内容が変わる可能性があります。

3. test_duplicator.pyを追加しました。一部のテストの実装と、今後実装予定のテストを記述しました。