### PR TITLE
OSC再分配機構の完成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           pip install -r requirements.txt
           pip install flake8
       - name: Run Flake8
-        run: flake8
+        run: flake8 --max-line-length 88
 
   tests:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           pip install -r requirements.txt
           pip install flake8
       - name: Run Flake8
-        run: flake8 --max-line-length 88
+        run: flake8
 
   tests:
     runs-on: windows-latest

--- a/oscduplicator/Settings.json
+++ b/oscduplicator/Settings.json
@@ -1,0 +1,8 @@
+{
+    "receive": {
+        "port": 9001
+    },
+    "transmit": [
+
+    ]
+}

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -1,56 +1,9 @@
 import json
 import queue
-from dataclasses import dataclass
 from threading import Thread
 
 from pythonosc import dispatcher, osc_server, udp_client
-
-
-@dataclass
-class TransmitPortSetting:
-    """
-    再送信先のポートのデータを保持する
-
-    Parameters
-    ---------
-    name: str
-        ポートの名称
-    port: int
-        ポート番号
-    enable: bool
-        そのポートに再送信するかどうか
-    """
-
-    name: str
-    port: int
-    enabled: bool
-
-    def __post_init__(self):
-        # Validate the 'name' attribute
-        if not isinstance(self.name, str):
-            raise TypeError(
-                "Expected instance of type 'str' for attribute 'name',"
-                f"but got '{type(self.name).__name__}'."
-            )
-
-        # Validate the 'port' attribute
-        if not isinstance(self.port, int):
-            raise TypeError(
-                "Expected instance of type 'int' for attribute 'port',"
-                f" but got '{type(self.port).__name__}'."
-            )
-        if not (0 <= self.port <= 65535):  # standard port range for TCP/UDP
-            raise ValueError(
-                "Invalid 'port' value. Expected a number between 0 and 65535, "
-                f"but got '{self.port}'."
-            )
-
-        # Validate the 'enabled' attribute
-        if not isinstance(self.enabled, bool):
-            raise TypeError(
-                "Expected instance of type 'bool' for attribute 'enabled',"
-                f" but got '{type(self.enabled).__name__}'."
-            )
+from setting import TransmitPortSetting
 
 
 class OSCDuplicator:

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -79,7 +79,7 @@ class OSCDuplicator:
         """
         self.__server.shutdown()
 
-    def __queue_osc(self, q: queue.Queue, address: str, *args: list) -> None:
+    def __queue_osc(self, address: str, *args: list) -> None:
         """
         受信したOSC信号をdictとして、キューに追加する
 
@@ -91,10 +91,10 @@ class OSCDuplicator:
             osc信号
         """
         d = {"address": address, "args": args}
-        q.put(d)
+        self.__q.put(d)
 
     def transmit_msg(
-        self, clients: list[udp_client.SimpleUDPClient], q: queue.Queue
+        self, clients: list[udp_client.SimpleUDPClient]
     ) -> None:
         """
         osc信号を転送する
@@ -112,7 +112,7 @@ class OSCDuplicator:
             return
 
         while True:
-            d = q.get()
+            d = self.__q.get()
             address: str = d["address"]
             args: list = d["args"]
 
@@ -127,7 +127,7 @@ class OSCDuplicator:
             for thread in threads:
                 thread.join()
 
-            q.task_done()
+            self.__q.task_done()
 
     def load_settings(self, file_path: str) -> None:
         """

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -167,7 +167,7 @@ class OSCDuplicator:
         with open(file_path, "r", encoding="UTF-8") as f:
             json_dic = json.load(f)
 
-        receive_port = json_dic["receive"]
+        receive_port = json_dic["receive"]["port"]
 
         transmit_port_settings: list[TransmitPortSetting] = [
             TransmitPortSetting(**i) for i in json_dic["transmit"]
@@ -191,13 +191,13 @@ class OSCDuplicator:
             ip = socket.gethostbyname(hostname)
             str_ip = str(ip)
             return udp_client.SimpleUDPClient(str_ip, port)
-
+        
         port_l: list[int] = []
         for tps in transmit_port_settings:
             if tps.enabled:
                 port_l.append(tps.port)
 
-        port_l = set(port_l)
+        port_l = list(set(port_l))
 
         self.clients = [__client(i) for i in port_l]
 
@@ -235,10 +235,9 @@ class OSCDuplicator:
         ]
 
         save_data: dict = {
-            "receive": [{"port": self.receive_port}],
-            "transmit": transmit_settings,
+            "receive": {"port": self.receive_port},
+            "transmit": transmit_settings
         }
 
-        json_data = json.dumps(save_data)
         with open(file_path, "w", encoding="UTF-8") as f:
-            json.dump(json_data, f, indent=4)
+            json.dump(save_data, f, indent=4)

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -66,10 +66,11 @@ class OSCDuplicator:
         port = self.receive_port if self.receive_port is not None else 9001
         dpt = dispatcher.Dispatcher()
 
+        # dpt.map("/*", print)
         dpt.map("/*", self.__queue_osc)
 
         self.__server = osc_server.ThreadingOSCUDPServer(
-            ("127.0.0.1", port), dpt
+            ("0.0.0.0", port), dpt
         )
         self.__server.serve_forever()
 
@@ -117,7 +118,7 @@ class OSCDuplicator:
             args: list = d["args"]
 
             threads = [
-                Thread(target=client.send_message, args=(address, args))
+                Thread(target=client.send_message, args=(address, args[0], ))
                 for client in clients
             ]
 

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -2,7 +2,6 @@ import json
 import queue
 from dataclasses import dataclass
 from threading import Thread
-from typing import Optional
 
 from pythonosc import dispatcher, osc_server, udp_client
 
@@ -73,9 +72,9 @@ class OSCDuplicator:
     """
 
     def __init__(self) -> None:
-        self.__receive_port: Optional[int] = None
+        self.__receive_port: int | None = None
         self.__transmit_port_settings: list[TransmitPortSetting] = []
-        self.__server: Optional[osc_server.ThreadingOSCUDPServer] = None
+        self.__server: osc_server.ThreadingOSCUDPServer | None = None
         self.__clients: list[udp_client.SimpleUDPClient] = []
         self.__q = queue.Queue()
 

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -107,7 +107,7 @@ class OSCDuplicator:
             {"address": address, "args": args}
         """
 
-        if len(clients) <= 0:
+        if not clients:
             return
 
         while True:

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -1,9 +1,11 @@
 import json
 import queue
+import socket
+from dataclasses import asdict
 from threading import Thread
 
 from pythonosc import dispatcher, osc_server, udp_client
-from setting import TransmitPortSetting
+from oscduplicator.setting import TransmitPortSetting
 
 
 class OSCDuplicator:
@@ -28,7 +30,7 @@ class OSCDuplicator:
         self.__receive_port: int | None = None
         self.__transmit_port_settings: list[TransmitPortSetting] = []
         self.__server: osc_server.ThreadingOSCUDPServer | None = None
-        self.__clients: list[udp_client.SimpleUDPClient] = []
+        self.clients: list[udp_client.SimpleUDPClient] = []
         self.__q = queue.Queue()
 
     @property
@@ -48,8 +50,10 @@ class OSCDuplicator:
         """
         # check value
         if not isinstance(value, int):
-            raise TypeError("Expected instance of type 'int' for attribute 'port'")
-        if not (0 <= value <= 65535):  # standard port range for TCP/UDP
+            raise TypeError(
+                "Expected instance of type 'int' for attribute 'port'"
+            )
+        if not (0 <= value <= 65535):
             raise ValueError(
                 "Invalid 'port' value. Expected a number between 0 and 65535"
             )
@@ -64,7 +68,9 @@ class OSCDuplicator:
 
         dpt.map("/*", self.__queue_osc)
 
-        self.__server = osc_server.ThreadingOSCUDPServer(("127.0.0.1", port), dpt)
+        self.__server = osc_server.ThreadingOSCUDPServer(
+            ("127.0.0.1", port), dpt
+        )
         self.__server.serve_forever()
 
     def stop_server(self) -> None:
@@ -88,7 +94,7 @@ class OSCDuplicator:
         q.put(d)
 
     def transmit_msg(
-        self, transmit_clients: list[udp_client.SimpleUDPClient], q: queue.Queue
+        self, clients: list[udp_client.SimpleUDPClient], q: queue.Queue
     ) -> None:
         """
         osc信号を転送する
@@ -102,7 +108,7 @@ class OSCDuplicator:
             {"address": address, "args": args}
         """
 
-        if len(transmit_clients) <= 0:
+        if len(clients) <= 0:
             return
 
         while True:
@@ -112,7 +118,7 @@ class OSCDuplicator:
 
             threads = [
                 Thread(target=client.send_message, args=(address, args))
-                for client in transmit_clients
+                for client in clients
             ]
 
             for thread in threads:
@@ -123,12 +129,27 @@ class OSCDuplicator:
 
             q.task_done()
 
-    def load_settings(self, file_path: str):
-        self.receive_port, self.transmit_list = self.__load_json(file_path)
+    def load_settings(self, file_path: str) -> None:
+        """
+        jsonファイルを読み込み、
+        self.__transmit_port_settingsと
+        self.clients
+        を更新する
+        起動時に呼び出される
+
+        Parameters
+        ---------
+        file_path: str
+            設定ファイルのパス
+        """
+        self.receive_port, self.__transmit_port_settings = self.__load_json(
+            file_path
+        )
+        self.__update_clients(self.__transmit_port_settings)
 
     def __load_json(self, file_path: str):
         """
-        jsonファイルから設定データを呼び出し
+        jsonファイルから設定データを呼び出す
 
         Parameters
         ---------
@@ -148,8 +169,76 @@ class OSCDuplicator:
 
         receive_port = json_dic["receive"]
 
-        transmit_list: list[TransmitPortSetting] = [
+        transmit_port_settings: list[TransmitPortSetting] = [
             TransmitPortSetting(**i) for i in json_dic["transmit"]
         ]
 
-        return receive_port, transmit_list
+        return receive_port, transmit_port_settings
+
+    def __update_clients(
+        self, transmit_port_settings: list[TransmitPortSetting]
+    ) -> None:
+        """
+        self.__clientsを更新する
+        load_settings()と
+        update_settings()で呼び出される
+
+        Parameters
+        """
+
+        def __client(port: int) -> udp_client.SimpleUDPClient:
+            hostname = socket.gethostname()
+            ip = socket.gethostbyname(hostname)
+            str_ip = str(ip)
+            return udp_client.SimpleUDPClient(str_ip, port)
+
+        port_l: list[int] = []
+        for tps in transmit_port_settings:
+            if tps.enabled:
+                port_l.append(tps.port)
+
+        port_l = set(port_l)
+
+        self.clients = [__client(i) for i in port_l]
+
+    def update_settings(
+        self,
+        receive_port: int,
+        transmit_port_settings: list[TransmitPortSetting],
+    ) -> None:
+        """
+        GUIでの入力内容から、
+        self.receive_portと
+        self.__transmit_port_settingsと
+        self.clients を更新する
+        OSCDuplicator内のstart_server()の前とsave_settings()の前に呼び出す
+
+        Parameters
+        ---------
+        receive_port: int
+        transmit_port_settings: list[TransmitPortSetting]
+            app側では入力内容からlist[TransmitPortSetting]を作成して引数として設定する
+            なんか二度手間なような気がする
+        """
+        self.receive_port = receive_port
+        self.__transmit_port_settings = transmit_port_settings
+        self.__update_clients(self.__transmit_port_settings)
+
+    def save_settings(self, file_path: str) -> None:
+        """
+        メンバ変数をjsonファイルにセーブする
+        終了時に呼び出す
+        """
+
+        transmit_settings: list[dict] = [
+            asdict(d) for d in self.__transmit_port_settings
+        ]
+
+        save_data: dict = {
+            "receive": [{"port": self.receive_port}],
+            "transmit": transmit_settings,
+        }
+
+        json_data = json.dumps(save_data)
+        with open(file_path, "w", encoding="UTF-8") as f:
+            json.dump(json_data, f, indent=4)

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -31,8 +31,8 @@ class OSCDuplicator:
     def __init__(self) -> None:
         self.__receive_port: int | None = None
         self.__transmit_port_settings: list[TransmitPortSetting] = []
-        self.__server: osc_server.ThreadingOSCUDPServer | None = None
-        self.clients: list[udp_client.SimpleUDPClient] = []
+        self.__server: ThreadingOSCUDPServer | None = None
+        self.clients: list[SimpleUDPClient] = []
         self.__q = queue.Queue()
 
     @property
@@ -66,12 +66,12 @@ class OSCDuplicator:
         OSCサーバーを初期化し、起動する
         """
         port = self.receive_port if self.receive_port is not None else 9001
-        dpt = dispatcher.Dispatcher()
+        dpt = Dispatcher()
 
         # dpt.map("/*", print)
         dpt.map("/*", self.__queue_osc)
 
-        self.__server = osc_server.ThreadingOSCUDPServer(
+        self.__server = ThreadingOSCUDPServer(
             ("0.0.0.0", port), dpt
         )
         self.__server.serve_forever()
@@ -96,7 +96,7 @@ class OSCDuplicator:
         d = {"address": address, "args": args}
         self.__q.put(d)
 
-    def transmit_msg(self, clients: list[udp_client.SimpleUDPClient]) -> None:
+    def transmit_msg(self, clients: list[SimpleUDPClient]) -> None:
         """
         osc信号を転送する
 
@@ -193,11 +193,11 @@ class OSCDuplicator:
         Parameters
         """
 
-        def __client(port: int) -> udp_client.SimpleUDPClient:
+        def __client(port: int) -> SimpleUDPClient:
             hostname = socket.gethostname()
             ip = socket.gethostbyname(hostname)
             str_ip = str(ip)
-            return udp_client.SimpleUDPClient(str_ip, port)
+            return SimpleUDPClient(str_ip, port)
 
         port_l: list[int] = []
         for tps in transmit_port_settings:

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -94,9 +94,7 @@ class OSCDuplicator:
         d = {"address": address, "args": args}
         self.__q.put(d)
 
-    def transmit_msg(
-        self, clients: list[udp_client.SimpleUDPClient]
-    ) -> None:
+    def transmit_msg(self, clients: list[udp_client.SimpleUDPClient]) -> None:
         """
         osc信号を転送する
 
@@ -118,7 +116,13 @@ class OSCDuplicator:
             args: list = d["args"]
 
             threads = [
-                Thread(target=client.send_message, args=(address, args[0], ))
+                Thread(
+                    target=client.send_message,
+                    args=(
+                        address,
+                        args[0],
+                    ),
+                )
                 for client in clients
             ]
 
@@ -192,7 +196,7 @@ class OSCDuplicator:
             ip = socket.gethostbyname(hostname)
             str_ip = str(ip)
             return udp_client.SimpleUDPClient(str_ip, port)
-        
+
         port_l: list[int] = []
         for tps in transmit_port_settings:
             if tps.enabled:
@@ -237,7 +241,7 @@ class OSCDuplicator:
 
         save_data: dict = {
             "receive": {"port": self.receive_port},
-            "transmit": transmit_settings
+            "transmit": transmit_settings,
         }
 
         with open(file_path, "w", encoding="UTF-8") as f:

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -1,0 +1,203 @@
+import json
+import queue
+from dataclasses import dataclass
+from threading import Thread
+from typing import Optional
+
+from pythonosc import dispatcher, osc_server, udp_client
+
+
+@dataclass
+class TransmitPortSetting:
+    """
+    再送信先のポートのデータを保持する
+
+    Parameters
+    ---------
+    name: str
+        ポートの名称
+    port: int
+        ポート番号
+    enable: bool
+        そのポートに再送信するかどうか
+    """
+
+    name: str
+    port: int
+    enabled: bool
+
+    def __post_init__(self):
+        # Validate the 'name' attribute
+        if not isinstance(self.name, str):
+            raise TypeError(
+                "Expected instance of type 'str' for attribute 'name',"
+                f"but got '{type(self.name).__name__}'."
+            )
+
+        # Validate the 'port' attribute
+        if not isinstance(self.port, int):
+            raise TypeError(
+                "Expected instance of type 'int' for attribute 'port',"
+                f" but got '{type(self.port).__name__}'."
+            )
+        if not (0 <= self.port <= 65535):  # standard port range for TCP/UDP
+            raise ValueError(
+                "Invalid 'port' value. Expected a number between 0 and 65535, "
+                f"but got '{self.port}'."
+            )
+
+        # Validate the 'enabled' attribute
+        if not isinstance(self.enabled, bool):
+            raise TypeError(
+                "Expected instance of type 'bool' for attribute 'enabled',"
+                f" but got '{type(self.enabled).__name__}'."
+            )
+
+
+class OSCDuplicator:
+    """
+    OSC信号を受信するためのサーバーと、再送信のための設定を保持する
+
+    Attributes
+    ---------
+    server: osc_server.ThreadingOSCUDPServer
+        OSC信号を受信するためのサーバー
+    receive_port: int
+        OSC信号を受信するためのポート、デフォルト9001
+    transmit_port_settings: list[TransmitPortSetting]
+        転送先ポートの設定を保持するリスト
+    clients: list[udp_client.SimpleUDPClient]
+        OSC信号を再送信するための、clientのリスト
+    q: queue.Queue
+        OSC信号の受信順・送信順を保証するためのキュー
+    """
+
+    def __init__(self) -> None:
+        self.__receive_port: Optional[int] = None
+        self.__transmit_port_settings: list[TransmitPortSetting] = []
+        self.__server: Optional[osc_server.ThreadingOSCUDPServer] = None
+        self.__clients: list[udp_client.SimpleUDPClient] = []
+        self.__q = queue.Queue()
+
+    @property
+    def receive_port(self):
+        return self.__receive_port
+
+    @receive_port.setter
+    def receive_port(self, value: int):
+        """
+        __receiver_portのsetter
+        値のチェックをする
+
+        Parameters
+        ---------
+        value: int
+            新しい受信ポート番号
+        """
+        # check value
+        if not isinstance(value, int):
+            raise TypeError("Expected instance of type 'int' for attribute 'port'")
+        if not (0 <= value <= 65535):  # standard port range for TCP/UDP
+            raise ValueError(
+                "Invalid 'port' value. Expected a number between 0 and 65535"
+            )
+        self.__receive_port = value
+
+    def start_server(self) -> None:
+        """
+        OSCサーバーを初期化し、起動する
+        """
+        port = self.receive_port if self.receive_port is not None else 9001
+        dpt = dispatcher.Dispatcher()
+
+        dpt.map("/*", self.__queue_osc)
+
+        self.__server = osc_server.ThreadingOSCUDPServer(("127.0.0.1", port), dpt)
+        self.__server.serve_forever()
+
+    def stop_server(self) -> None:
+        """
+        OSCサーバーを終了する
+        """
+        self.__server.shutdown()
+
+    def __queue_osc(self, q: queue.Queue, address: str, *args: list) -> None:
+        """
+        受信したOSC信号をdictとして、キューに追加する
+
+        Parameters
+        ---------
+        address: str
+            受信・再送信アドレス
+        args: list
+            osc信号
+        """
+        d = {"address": address, "args": args}
+        q.put(d)
+
+    def transmit_msg(
+        self, transmit_clients: list[udp_client.SimpleUDPClient], q: queue.Queue
+    ) -> None:
+        """
+        osc信号を転送する
+
+        Parameters
+        ---------
+        transmit_clients: list[udp_client.SimpleUDPClient]
+            OSC信号を再送信するための、clientのリスト
+        q: queue.Queue
+            キュー
+            {"address": address, "args": args}
+        """
+
+        if len(transmit_clients) <= 0:
+            return
+
+        while True:
+            d = q.get()
+            address: str = d["address"]
+            args: list = d["args"]
+
+            threads = [
+                Thread(target=client.send_message, args=(address, args))
+                for client in transmit_clients
+            ]
+
+            for thread in threads:
+                thread.start()
+
+            for thread in threads:
+                thread.join()
+
+            q.task_done()
+
+    def load_settings(self, file_path: str):
+        self.receive_port, self.transmit_list = self.__load_json(file_path)
+
+    def __load_json(self, file_path: str):
+        """
+        jsonファイルから設定データを呼び出し
+
+        Parameters
+        ---------
+        file_path: str
+            設定ファイルのパス
+
+        Returns
+        ---------
+        receive_port: int
+            受信ポート
+        transmit_list: list[TransmitPortSettings]
+            分配ポートのセッティング(dataclass)のリスト
+        """
+
+        with open(file_path, "r", encoding="UTF-8") as f:
+            json_dic = json.load(f)
+
+        receive_port = json_dic["receive"]
+
+        transmit_list: list[TransmitPortSetting] = [
+            TransmitPortSetting(**i) for i in json_dic["transmit"]
+        ]
+
+        return receive_port, transmit_list

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -4,7 +4,9 @@ import socket
 from dataclasses import asdict
 from threading import Thread
 
-from pythonosc import dispatcher, osc_server, udp_client
+from pythonosc.dispatcher import Dispatcher
+from pythonosc.osc_server import ThreadingOSCUDPServer
+from pythonosc.udp_client import SimpleUDPClient
 from oscduplicator.setting import TransmitPortSetting
 
 

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -247,4 +247,4 @@ class OSCDuplicator:
         }
 
         with open(file_path, "w", encoding="UTF-8") as f:
-            json.dump(save_data, f, indent=4)
+            json.dump(save_data, f, indent=4, ensure_ascii=False)

--- a/oscduplicator/setting.py
+++ b/oscduplicator/setting.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import Any
+
 
 @dataclass
 class TransmitPortSetting:
@@ -20,28 +22,90 @@ class TransmitPortSetting:
     enabled: bool
 
     def __post_init__(self):
-        # Validate the 'name' attribute
-        if not isinstance(self.name, str):
+        self.validate_name(self.name)
+        self.validate_port(self.port)
+        self.validate_enabled(self.enabled)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        """
+        各値のsetattr
+
+        Parameters
+        ---------
+        key: str
+            "name" | "port" | "enable"
+        value: any
+            代入したい値
+        """
+        validate_methoad = getattr(self, f"validate_{key}", None)
+        if validate_methoad:
+            value = validate_methoad(value)
+        super().__setattr__(key, value)
+
+    @staticmethod
+    def validate_name(name):
+        """
+        nameを評価する
+        int, floatの場合はstrに変換
+
+        Parameters
+        ---------
+        name: str | int | float
+
+        Returns
+        ---------
+        name: str
+        """
+        if isinstance(name, (int, float)):
+            return str(name)
+        elif not isinstance(name, str):
             raise TypeError(
                 "Expected instance of type 'str' for attribute 'name',"
-                f"but got '{type(self.name).__name__}'."
+                f"but got '{type(name).__name__}'."
             )
 
-        # Validate the 'port' attribute
-        if not isinstance(self.port, int):
+    @staticmethod
+    def validate_port(port):
+        """
+        portを評価する
+
+        Parameters
+        ---------
+        port: int
+            0 ~ 65535
+
+        Returns
+        ---------
+        port: int
+        """
+        if not isinstance(port, int):
             raise TypeError(
                 "Expected instance of type 'int' for attribute 'port',"
-                f" but got '{type(self.port).__name__}'."
+                f" but got '{type(port).__name__}'."
             )
-        if not (0 <= self.port <= 65535):  # standard port range for TCP/UDP
+        if not (0 <= port <= 65535):  # standard port range for TCP/UDP
             raise ValueError(
                 "Invalid 'port' value. Expected a number between 0 and 65535, "
-                f"but got '{self.port}'."
+                f"but got '{port}'."
             )
+        return port
 
-        # Validate the 'enabled' attribute
-        if not isinstance(self.enabled, bool):
+    @staticmethod
+    def validate_enabled(enabled):
+        """
+        enableを評価する
+
+        Parameters
+        ---------
+        enable: bool
+
+        Returns
+        ---------
+        enable: bool
+        """
+        if not isinstance(enabled, bool):
             raise TypeError(
                 "Expected instance of type 'bool' for attribute 'enabled',"
-                f" but got '{type(self.enabled).__name__}'."
+                f" but got '{type(enabled).__name__}'."
             )
+        return enabled

--- a/oscduplicator/setting.py
+++ b/oscduplicator/setting.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+@dataclass
+class TransmitPortSetting:
+    """
+    再送信先のポートのデータを保持する
+
+    Parameters
+    ---------
+    name: str
+        ポートの名称
+    port: int
+        ポート番号
+    enable: bool
+        そのポートに再送信するかどうか
+    """
+
+    name: str
+    port: int
+    enabled: bool
+
+    def __post_init__(self):
+        # Validate the 'name' attribute
+        if not isinstance(self.name, str):
+            raise TypeError(
+                "Expected instance of type 'str' for attribute 'name',"
+                f"but got '{type(self.name).__name__}'."
+            )
+
+        # Validate the 'port' attribute
+        if not isinstance(self.port, int):
+            raise TypeError(
+                "Expected instance of type 'int' for attribute 'port',"
+                f" but got '{type(self.port).__name__}'."
+            )
+        if not (0 <= self.port <= 65535):  # standard port range for TCP/UDP
+            raise ValueError(
+                "Invalid 'port' value. Expected a number between 0 and 65535, "
+                f"but got '{self.port}'."
+            )
+
+        # Validate the 'enabled' attribute
+        if not isinstance(self.enabled, bool):
+            raise TypeError(
+                "Expected instance of type 'bool' for attribute 'enabled',"
+                f" but got '{type(self.enabled).__name__}'."
+            )

--- a/oscduplicator/setting.py
+++ b/oscduplicator/setting.py
@@ -22,9 +22,9 @@ class TransmitPortSetting:
     enabled: bool
 
     def __post_init__(self):
-        self.validate_name(self.name)
-        self.validate_port(self.port)
-        self.validate_enabled(self.enabled)
+        self.name = self.validate_name(self.name)
+        self.port = self.validate_port(self.port)
+        self.enabled = self.validate_enabled(self.enabled)
 
     def __setattr__(self, key: str, value: Any) -> None:
         """
@@ -37,9 +37,9 @@ class TransmitPortSetting:
         value: any
             代入したい値
         """
-        validate_methoad = getattr(self, f"validate_{key}", None)
-        if validate_methoad:
-            value = validate_methoad(value)
+        validate_method = getattr(self, f"validate_{key}", None)
+        if validate_method:
+            value = validate_method(value)
         super().__setattr__(key, value)
 
     @staticmethod
@@ -63,6 +63,7 @@ class TransmitPortSetting:
                 "Expected instance of type 'str' for attribute 'name',"
                 f"but got '{type(name).__name__}'."
             )
+        return name
 
     @staticmethod
     def validate_port(port):
@@ -83,7 +84,7 @@ class TransmitPortSetting:
                 "Expected instance of type 'int' for attribute 'port',"
                 f" but got '{type(port).__name__}'."
             )
-        if not (0 <= port <= 65535):  # standard port range for TCP/UDP
+        if not (0 <= port <= 65535):
             raise ValueError(
                 "Invalid 'port' value. Expected a number between 0 and 65535, "
                 f"but got '{port}'."

--- a/tests/integration_tests/integration_test_Settings.json
+++ b/tests/integration_tests/integration_test_Settings.json
@@ -1,0 +1,32 @@
+{
+    "receive": {
+        "port": 9000
+    },
+    "transmit": [
+        {
+            "name": "test0_t",
+            "port": 9003,
+            "enabled": true
+        },
+        {
+            "name": "test1_t",
+            "port": 9004,
+            "enabled": true
+        },
+        {
+            "name": "test2_t",
+            "port": 9005,
+            "enabled": true
+        },
+        {
+            "name": "test3_t",
+            "port": 9005,
+            "enabled": true
+        },
+        {
+            "name": "test4_f",
+            "port": 9006,
+            "enabled": false
+        }
+    ]
+}

--- a/tests/integration_tests/osc_relay_integration_test.py
+++ b/tests/integration_tests/osc_relay_integration_test.py
@@ -2,7 +2,10 @@ import socket
 from threading import Thread
 from time import perf_counter, sleep
 
-from pythonosc import dispatcher, osc_server, udp_client
+from pythonosc.dispatcher import Dispatcher
+from pythonosc.osc_server import ThreadingOSCUDPServer
+from pythonosc.udp_client import SimpleUDPClient
+
 
 from oscduplicator.duplicator import OSCDuplicator
 
@@ -36,11 +39,11 @@ class OscRelayIntegrationTest:
         10回、pref_counterの値を送る
         """
 
-        def __client(port: int) -> udp_client.SimpleUDPClient:
+        def __client(port: int) -> SimpleUDPClient:
             hostname = socket.gethostname()
             ip = socket.gethostbyname(hostname)
             str_ip = str(ip)
-            return udp_client.SimpleUDPClient(str_ip, port)
+            return SimpleUDPClient(str_ip, port)
 
         client = __client(9000)
 
@@ -57,10 +60,10 @@ class OscRelayIntegrationTest:
         """
 
         def __launch_osc_receiver(port: int):
-            dpt = dispatcher.Dispatcher()
+            dpt = Dispatcher()
             dpt.map("/*", self.osc_handler, port)
 
-            server = osc_server.ThreadingOSCUDPServer(("0.0.0.0", port), dpt)
+            server = ThreadingOSCUDPServer(("0.0.0.0", port), dpt)
             server.serve_forever()
 
         ports = [9003, 9004, 9005, 9006]

--- a/tests/integration_tests/osc_relay_integration_test.py
+++ b/tests/integration_tests/osc_relay_integration_test.py
@@ -1,22 +1,18 @@
 import socket
-import pytest
 from threading import Thread
 from time import perf_counter, sleep
 
 from pythonosc import dispatcher, osc_server, udp_client
 
 from oscduplicator.duplicator import OSCDuplicator
-from oscduplicator.setting import TransmitPortSetting
 
 
 class OscRelayIntegrationTest:
-
-
     def __init__(self) -> None:
-         self.result_9003 = []
-         self.result_9004 = []
-         self.result_9005 = []
-         self.result_9006 = []
+        self.result_9003 = []
+        self.result_9004 = []
+        self.result_9005 = []
+        self.result_9006 = []
 
     def run_duplicator(self):
         duplicator = OSCDuplicator()
@@ -25,7 +21,11 @@ class OscRelayIntegrationTest:
 
         duplicator.load_settings(SAVE_FILE)
 
-        th = Thread(target=duplicator.transmit_msg, args=(duplicator.clients, ), daemon=True)
+        th = Thread(
+            target=duplicator.transmit_msg,
+            args=(duplicator.clients,),
+            daemon=True,
+        )
         th.start()
 
         duplicator.start_server()
@@ -37,11 +37,11 @@ class OscRelayIntegrationTest:
         """
 
         def __client(port: int) -> udp_client.SimpleUDPClient:
-                hostname = socket.gethostname()
-                ip = socket.gethostbyname(hostname)
-                str_ip = str(ip)
-                return udp_client.SimpleUDPClient(str_ip, port)
-        
+            hostname = socket.gethostname()
+            ip = socket.gethostbyname(hostname)
+            str_ip = str(ip)
+            return udp_client.SimpleUDPClient(str_ip, port)
+
         client = __client(9000)
 
         count = 0
@@ -55,7 +55,7 @@ class OscRelayIntegrationTest:
         """
         OSCの受信サーバーを立ち上げ
         """
-        
+
         def __launch_osc_receiver(port: int):
             dpt = dispatcher.Dispatcher()
             dpt.map("/*", self.osc_handler, port)
@@ -64,7 +64,10 @@ class OscRelayIntegrationTest:
             server.serve_forever()
 
         ports = [9003, 9004, 9005, 9006]
-        receivers_thread = [Thread(target=__launch_osc_receiver, args=(port, )) for port in ports]
+        receivers_thread = [
+            Thread(target=__launch_osc_receiver, args=(port,))
+            for port in ports
+        ]
 
         for th in receivers_thread:
             th.start()
@@ -78,6 +81,7 @@ class OscRelayIntegrationTest:
             self.result_9005.append(args[0])
         elif port[0] == 9006:
             self.result_9006.append(args[0])
+
 
 def check_receiverd_value(result_: list) -> bool:
     """
@@ -95,13 +99,13 @@ def check_receiverd_value(result_: list) -> bool:
         return False
 
     for i in range(len(result_) - 1):
-        if result_[i] >= result_[i+1]:
+        if result_[i] >= result_[i + 1]:
             return False
-    
+
     return True
 
-def test_osc_relay_integration():
 
+def test_osc_relay_integration():
     test = OscRelayIntegrationTest()
 
     th0 = Thread(target=test.run_duplicator, daemon=True)
@@ -117,8 +121,7 @@ def test_osc_relay_integration():
 
     sleep(3)
 
-    assert check_receiverd_value(test.result_9003) == True
-    assert check_receiverd_value(test.result_9004) == True
-    assert check_receiverd_value(test.result_9005) == True
+    assert check_receiverd_value(test.result_9003) is True
+    assert check_receiverd_value(test.result_9004) is True
+    assert check_receiverd_value(test.result_9005) is True
     assert len(test.result_9006) == 0
-

--- a/tests/integration_tests/osc_relay_integration_test.py
+++ b/tests/integration_tests/osc_relay_integration_test.py
@@ -1,0 +1,124 @@
+import socket
+import pytest
+from threading import Thread
+from time import perf_counter, sleep
+
+from pythonosc import dispatcher, osc_server, udp_client
+
+from oscduplicator.duplicator import OSCDuplicator
+from oscduplicator.setting import TransmitPortSetting
+
+
+class OscRelayIntegrationTest:
+
+
+    def __init__(self) -> None:
+         self.result_9003 = []
+         self.result_9004 = []
+         self.result_9005 = []
+         self.result_9006 = []
+
+    def run_duplicator(self):
+        duplicator = OSCDuplicator()
+
+        SAVE_FILE = "./tests/integration_tests/integration_test_Settings.json"
+
+        duplicator.load_settings(SAVE_FILE)
+
+        th = Thread(target=duplicator.transmit_msg, args=(duplicator.clients, ), daemon=True)
+        th.start()
+
+        duplicator.start_server()
+
+    def launch_osc_sender(self):
+        """
+        OSCのクライアントを作成
+        10回、pref_counterの値を送る
+        """
+
+        def __client(port: int) -> udp_client.SimpleUDPClient:
+                hostname = socket.gethostname()
+                ip = socket.gethostbyname(hostname)
+                str_ip = str(ip)
+                return udp_client.SimpleUDPClient(str_ip, port)
+        
+        client = __client(9000)
+
+        count = 0
+        while count < 10:
+            msg = perf_counter()
+            client.send_message("/perf_counter", msg)
+            sleep(0.2)
+            count += 1
+
+    def launch_osc_receivers(self):
+        """
+        OSCの受信サーバーを立ち上げ
+        """
+        
+        def __launch_osc_receiver(port: int):
+            dpt = dispatcher.Dispatcher()
+            dpt.map("/*", self.osc_handler, port)
+
+            server = osc_server.ThreadingOSCUDPServer(("0.0.0.0", port), dpt)
+            server.serve_forever()
+
+        ports = [9003, 9004, 9005, 9006]
+        receivers_thread = [Thread(target=__launch_osc_receiver, args=(port, )) for port in ports]
+
+        for th in receivers_thread:
+            th.start()
+
+    def osc_handler(self, address: str, port: list[int], *args: list):
+        if port[0] == 9003:
+            self.result_9003.append(args[0])
+        elif port[0] == 9004:
+            self.result_9004.append(args[0])
+        elif port[0] == 9005:
+            self.result_9005.append(args[0])
+        elif port[0] == 9006:
+            self.result_9006.append(args[0])
+
+def check_receiverd_value(result_: list) -> bool:
+    """
+    OSCの受信結果をチェックする
+    チェック事項
+    1. 受信した信号の個数(10個)
+    2. 送信順と受信順に変化がないか
+
+    Parameter
+    ---------
+    result_: list
+        受信したOSC信号のリスト
+    """
+    if len(result_) != 10:
+        return False
+
+    for i in range(len(result_) - 1):
+        if result_[i] >= result_[i+1]:
+            return False
+    
+    return True
+
+def test_osc_relay_integration():
+
+    test = OscRelayIntegrationTest()
+
+    th0 = Thread(target=test.run_duplicator, daemon=True)
+    th1 = Thread(target=test.launch_osc_receivers, daemon=True)
+    th2 = Thread(target=test.launch_osc_sender, daemon=True)
+
+    th0.start()
+    th1.start()
+
+    sleep(3)
+
+    th2.start()
+
+    sleep(3)
+
+    assert check_receiverd_value(test.result_9003) == True
+    assert check_receiverd_value(test.result_9004) == True
+    assert check_receiverd_value(test.result_9005) == True
+    assert len(test.result_9006) == 0
+

--- a/tests/test_Settings.json
+++ b/tests/test_Settings.json
@@ -4,23 +4,28 @@
     },
     "transmit": [
         {
-            "name": "test1_t",
+            "name": "test0_t",
             "port": 9001,
             "enabled": true
         },
         {
-            "name": "test2_t",
+            "name": "test1_t",
             "port": 9002,
             "enabled": true
         },
         {
-            "name": "test3_f",
+            "name": "test2_t",
             "port": 9003,
-            "enabled": false
+            "enabled": true
         },
         {
-            "name": "test3_f",
+            "name": "test3_t",
             "port": 9003,
+            "enabled": true
+        },
+        {
+            "name": "test4_f",
+            "port": 9004,
             "enabled": false
         }
     ]

--- a/tests/test_Settings.json
+++ b/tests/test_Settings.json
@@ -1,0 +1,27 @@
+{
+    "receive": {
+        "port": 9001
+    },
+    "transmit": [
+        {
+            "name": "test1_t",
+            "port": 9001,
+            "enabled": true
+        },
+        {
+            "name": "test2_t",
+            "port": 9002,
+            "enabled": true
+        },
+        {
+            "name": "test3_f",
+            "port": 9003,
+            "enabled": false
+        },
+        {
+            "name": "test3_f",
+            "port": 9003,
+            "enabled": false
+        }
+    ]
+}

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -1,10 +1,12 @@
+import random, string
 from threading import Thread
 from time import sleep
 
 import pytest
 from pythonosc import osc_server
 
-from oscduplicator.duplicator import OSCDuplicator, TransmitPortSetting
+from oscduplicator.duplicator import OSCDuplicator
+from oscduplicator.setting import TransmitPortSetting
 
 
 class TestDuplicator:
@@ -43,26 +45,101 @@ class TestDuplicator:
         sleep(1)
         assert __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server) is True
 
+    def __transmit_port_settings(self):
+        """
+        transmit_port_settingsのゲッター
+        """
+        return self.osc_duplicator._OSCDuplicator__transmit_port_settings
+
     def test_load_settings(self):
         """
         正しくjsonファイルを読み込めるかテスト
         """
-        pass
+        # Arrange
+        FILE_PATH = "./tests/test_Settings.json"
+        # Act
+        self.osc_duplicator.load_settings(FILE_PATH)
+        # Assert
+        assert self.osc_duplicator.receive_port == 9001
+
+        assert self.__transmit_port_settings()[0].name == "test0_t"
+        assert self.__transmit_port_settings()[0].port == 9001
+        assert self.__transmit_port_settings()[0].enabled == True
+
+        assert self.__transmit_port_settings()[1].name == "test1_t"
+        assert self.__transmit_port_settings()[1].port == 9002
+        assert self.__transmit_port_settings()[1].enabled == True
+
+        assert self.__transmit_port_settings()[4].name == "test4_f"
+        assert self.__transmit_port_settings()[4].port == 9004
+        assert self.__transmit_port_settings()[4].enabled == False
+
+        print(len(self.osc_duplicator.clients))
+
+        assert set(client._port for client in self.osc_duplicator.clients) == set([9001, 9002, 9003])
 
     def test_update_settings(self):
         """
         class Duplicatorの設定を書き換えれるかテスト
         """
-        pass
+        def __random_name():
+            return "".join(random.choices(string.ascii_letters + string.digits, k=8))
+
+        def __random_port():
+            return random.randrange(start=0, stop=65535, step=1)
+
+        # Arrange
+        new_receive_port = 8001
+        new_transmit_port_settings = [TransmitPortSetting(__random_name(), __random_port(), True) for _ in range(4)]
+
+        # Act
+        self.osc_duplicator.update_settings(new_receive_port, new_transmit_port_settings)
+
+        # Assert
+        assert self.osc_duplicator.receive_port == 8001
+
+        assert self.__transmit_port_settings()[0].name == new_transmit_port_settings[0].name
+        assert self.__transmit_port_settings()[0].port == new_transmit_port_settings[0].port
+        assert self.__transmit_port_settings()[0].enabled == True
+        assert self.__transmit_port_settings()[3].name == new_transmit_port_settings[3].name
+        assert self.__transmit_port_settings()[3].port == new_transmit_port_settings[3].port
+        assert self.__transmit_port_settings()[3].enabled == True
+
+        assert set(client._port for client in self.osc_duplicator.clients) == set([tps.port for tps in new_transmit_port_settings])
 
     def test_save_settings(self):
         """
         正しくjsonファイルを書き出せるかテスト
         """
-        pass
+        def __random_name():
+            return "".join(random.choices(string.ascii_letters + string.digits, k=8))
 
-    def test_transmit_msg(self):
-        """
-        キューからOSC信号を取り出し、転送できるかテストする
-        """
-        pass
+        def __random_port():
+            return random.randrange(start=0, stop=65535, step=1)
+
+        # Arrange
+        new_receive_port = 8001
+        new_transmit_port_settings = [TransmitPortSetting(__random_name(), __random_port(), True) for _ in range(4)]
+
+        # Act
+        SAVE_FILE_PATH = "./tests/test_save_Settings.json"
+        self.osc_duplicator.update_settings(new_receive_port, new_transmit_port_settings)
+        self.osc_duplicator.save_settings(SAVE_FILE_PATH)
+
+        self.osc_duplicator.load_settings(SAVE_FILE_PATH)
+
+        # Assert
+        assert self.osc_duplicator.receive_port == 8001
+
+        assert self.__transmit_port_settings()[0].name == new_transmit_port_settings[0].name
+        assert self.__transmit_port_settings()[0].port == new_transmit_port_settings[0].port
+        assert self.__transmit_port_settings()[0].enabled == True
+        assert self.__transmit_port_settings()[3].name == new_transmit_port_settings[3].name
+        assert self.__transmit_port_settings()[3].port == new_transmit_port_settings[3].port
+        assert self.__transmit_port_settings()[3].enabled == True
+
+    # def test_transmit_msg(self):
+    #     """
+    #     キューからOSC信号を取り出し、転送できるかテストする
+    #     """
+    #     pass

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -1,8 +1,8 @@
-import random, string
+import random
+import string
 from threading import Thread
 from time import sleep
 
-import pytest
 from pythonosc import osc_server
 
 from oscduplicator.duplicator import OSCDuplicator
@@ -39,11 +39,15 @@ class TestDuplicator:
 
         sleep(1)
         assert (
-            __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server) is False
+            __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server)
+            is False
         )
         self.osc_duplicator.stop_server()
         sleep(1)
-        assert __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server) is True
+        assert (
+            __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server)
+            is True
+        )
 
     def __transmit_port_settings(self):
         """
@@ -64,66 +68,98 @@ class TestDuplicator:
 
         assert self.__transmit_port_settings()[0].name == "test0_t"
         assert self.__transmit_port_settings()[0].port == 9001
-        assert self.__transmit_port_settings()[0].enabled == True
+        assert self.__transmit_port_settings()[0].enabled is True
 
         assert self.__transmit_port_settings()[1].name == "test1_t"
         assert self.__transmit_port_settings()[1].port == 9002
-        assert self.__transmit_port_settings()[1].enabled == True
+        assert self.__transmit_port_settings()[1].enabled is True
 
         assert self.__transmit_port_settings()[4].name == "test4_f"
         assert self.__transmit_port_settings()[4].port == 9004
-        assert self.__transmit_port_settings()[4].enabled == False
+        assert self.__transmit_port_settings()[4].enabled is False
 
         print(len(self.osc_duplicator.clients))
 
-        assert set(client._port for client in self.osc_duplicator.clients) == set([9001, 9002, 9003])
+        assert set(
+            client._port for client in self.osc_duplicator.clients
+        ) == set([9001, 9002, 9003])
 
     def test_update_settings(self):
         """
         class Duplicatorの設定を書き換えれるかテスト
         """
+
         def __random_name():
-            return "".join(random.choices(string.ascii_letters + string.digits, k=8))
+            return "".join(
+                random.choices(string.ascii_letters + string.digits, k=8)
+            )
 
         def __random_port():
             return random.randrange(start=0, stop=65535, step=1)
 
         # Arrange
         new_receive_port = 8001
-        new_transmit_port_settings = [TransmitPortSetting(__random_name(), __random_port(), True) for _ in range(4)]
+        new_transmit_port_settings = [
+            TransmitPortSetting(__random_name(), __random_port(), True)
+            for _ in range(4)
+        ]
 
         # Act
-        self.osc_duplicator.update_settings(new_receive_port, new_transmit_port_settings)
+        self.osc_duplicator.update_settings(
+            new_receive_port, new_transmit_port_settings
+        )
 
         # Assert
         assert self.osc_duplicator.receive_port == 8001
 
-        assert self.__transmit_port_settings()[0].name == new_transmit_port_settings[0].name
-        assert self.__transmit_port_settings()[0].port == new_transmit_port_settings[0].port
-        assert self.__transmit_port_settings()[0].enabled == True
-        assert self.__transmit_port_settings()[3].name == new_transmit_port_settings[3].name
-        assert self.__transmit_port_settings()[3].port == new_transmit_port_settings[3].port
-        assert self.__transmit_port_settings()[3].enabled == True
+        assert (
+            self.__transmit_port_settings()[0].name
+            == new_transmit_port_settings[0].name
+        )
+        assert (
+            self.__transmit_port_settings()[0].port
+            == new_transmit_port_settings[0].port
+        )
+        assert self.__transmit_port_settings()[0].enabled is True
+        assert (
+            self.__transmit_port_settings()[3].name
+            == new_transmit_port_settings[3].name
+        )
+        assert (
+            self.__transmit_port_settings()[3].port
+            == new_transmit_port_settings[3].port
+        )
+        assert self.__transmit_port_settings()[3].enabled is True
 
-        assert set(client._port for client in self.osc_duplicator.clients) == set([tps.port for tps in new_transmit_port_settings])
+        assert set(
+            client._port for client in self.osc_duplicator.clients
+        ) == set([tps.port for tps in new_transmit_port_settings])
 
     def test_save_settings(self):
         """
         正しくjsonファイルを書き出せるかテスト
         """
+
         def __random_name():
-            return "".join(random.choices(string.ascii_letters + string.digits, k=8))
+            return "".join(
+                random.choices(string.ascii_letters + string.digits, k=8)
+            )
 
         def __random_port():
             return random.randrange(start=0, stop=65535, step=1)
 
         # Arrange
         new_receive_port = 8001
-        new_transmit_port_settings = [TransmitPortSetting(__random_name(), __random_port(), True) for _ in range(4)]
+        new_transmit_port_settings = [
+            TransmitPortSetting(__random_name(), __random_port(), True)
+            for _ in range(4)
+        ]
 
         # Act
         SAVE_FILE_PATH = "./tests/test_save_Settings.json"
-        self.osc_duplicator.update_settings(new_receive_port, new_transmit_port_settings)
+        self.osc_duplicator.update_settings(
+            new_receive_port, new_transmit_port_settings
+        )
         self.osc_duplicator.save_settings(SAVE_FILE_PATH)
 
         self.osc_duplicator.load_settings(SAVE_FILE_PATH)
@@ -131,12 +167,24 @@ class TestDuplicator:
         # Assert
         assert self.osc_duplicator.receive_port == 8001
 
-        assert self.__transmit_port_settings()[0].name == new_transmit_port_settings[0].name
-        assert self.__transmit_port_settings()[0].port == new_transmit_port_settings[0].port
-        assert self.__transmit_port_settings()[0].enabled == True
-        assert self.__transmit_port_settings()[3].name == new_transmit_port_settings[3].name
-        assert self.__transmit_port_settings()[3].port == new_transmit_port_settings[3].port
-        assert self.__transmit_port_settings()[3].enabled == True
+        assert (
+            self.__transmit_port_settings()[0].name
+            == new_transmit_port_settings[0].name
+        )
+        assert (
+            self.__transmit_port_settings()[0].port
+            == new_transmit_port_settings[0].port
+        )
+        assert self.__transmit_port_settings()[0].enabled is True
+        assert (
+            self.__transmit_port_settings()[3].name
+            == new_transmit_port_settings[3].name
+        )
+        assert (
+            self.__transmit_port_settings()[3].port
+            == new_transmit_port_settings[3].port
+        )
+        assert self.__transmit_port_settings()[3].enabled is True
 
     # def test_transmit_msg(self):
     #     """

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -7,36 +7,6 @@ from pythonosc import osc_server
 from oscduplicator.duplicator import OSCDuplicator, TransmitPortSetting
 
 
-class TestTransmitPortSettings:
-    def test_init_TransmitPortSettings(self):
-        """
-        TransmitPortSettingが不正な値に対して例外を出せるかテスト
-        """
-
-        # correct data
-        port_settings = TransmitPortSetting("Port0", 9000, True)
-        assert port_settings.name == "Port0"
-        assert port_settings.port == 9000
-        assert port_settings.enabled is True
-
-        # incorrect data type
-        with pytest.raises(TypeError):
-            TransmitPortSetting(123, 9000, False)
-
-        with pytest.raises(TypeError):
-            TransmitPortSetting("設定", "9000", True)
-
-        # incorrect data value
-        with pytest.raises(ValueError):
-            TransmitPortSetting("koya_so", -1, True)
-
-        with pytest.raises(ValueError):
-            TransmitPortSetting("koya_so", 65536, True)
-
-        with pytest.raises(TypeError):
-            TransmitPortSetting("nyanko", 8000, "neko")
-
-
 class TestDuplicator:
     osc_duplicator = OSCDuplicator()
     # def test_start_server(self):

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -1,0 +1,98 @@
+from threading import Thread
+from time import sleep
+
+import pytest
+from pythonosc import osc_server
+
+from oscduplicator.duplicator import OSCDuplicator, TransmitPortSetting
+
+
+class TestTransmitPortSettings:
+    def test_init_TransmitPortSettings(self):
+        """
+        TransmitPortSettingが不正な値に対して例外を出せるかテスト
+        """
+
+        # correct data
+        port_settings = TransmitPortSetting("Port0", 9000, True)
+        assert port_settings.name == "Port0"
+        assert port_settings.port == 9000
+        assert port_settings.enabled is True
+
+        # incorrect data type
+        with pytest.raises(TypeError):
+            TransmitPortSetting(123, 9000, False)
+
+        with pytest.raises(TypeError):
+            TransmitPortSetting("設定", "9000", True)
+
+        # incorrect data value
+        with pytest.raises(ValueError):
+            TransmitPortSetting("koya_so", -1, True)
+
+        with pytest.raises(ValueError):
+            TransmitPortSetting("koya_so", 65536, True)
+
+        with pytest.raises(TypeError):
+            TransmitPortSetting("nyanko", 8000, "neko")
+
+
+class TestDuplicator:
+    osc_duplicator = OSCDuplicator()
+    # def test_start_server(self):
+    #     """
+    #     サーバーを起動できるかテスト
+    #     """
+    #     pass
+
+    def test_start_stop_server(self):
+        """
+        サーバーを起動・停止できるかテスト
+        """
+
+        def __server_is_shut_down(server: osc_server.ThreadingOSCUDPServer):
+            """
+            サーバーがシャットダウンしているかどうか判定する
+            """
+            return server._BaseServer__is_shut_down.is_set()
+
+        assert self.osc_duplicator.receive_port is None
+
+        self.osc_duplicator.receive_port = 9001
+
+        assert self.osc_duplicator.receive_port == 9001
+
+        th = Thread(target=self.osc_duplicator.start_server, daemon=True)
+        th.start()
+
+        sleep(1)
+        assert (
+            __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server) is False
+        )
+        self.osc_duplicator.stop_server()
+        sleep(1)
+        assert __server_is_shut_down(self.osc_duplicator._OSCDuplicator__server) is True
+
+    def test_load_settings(self):
+        """
+        正しくjsonファイルを読み込めるかテスト
+        """
+        pass
+
+    def test_update_settings(self):
+        """
+        class Duplicatorの設定を書き換えれるかテスト
+        """
+        pass
+
+    def test_save_settings(self):
+        """
+        正しくjsonファイルを書き出せるかテスト
+        """
+        pass
+
+    def test_transmit_msg(self):
+        """
+        キューからOSC信号を取り出し、転送できるかテストする
+        """
+        pass

--- a/tests/test_save_Settings.json
+++ b/tests/test_save_Settings.json
@@ -1,0 +1,27 @@
+{
+    "receive": {
+        "port": 8001
+    },
+    "transmit": [
+        {
+            "name": "4Yqb6wlk",
+            "port": 39668,
+            "enabled": true
+        },
+        {
+            "name": "9cmA2lZd",
+            "port": 31136,
+            "enabled": true
+        },
+        {
+            "name": "3JVeS3w7",
+            "port": 36976,
+            "enabled": true
+        },
+        {
+            "name": "fxUwxKCn",
+            "port": 3441,
+            "enabled": true
+        }
+    ]
+}

--- a/tests/test_setting.py
+++ b/tests/test_setting.py
@@ -8,7 +8,7 @@ class TestTransmitPortSetting:
         tps = TransmitPortSetting("Test", 8080, True)
         assert tps.name == "Test"
         assert tps.port == 8080
-        assert tps.enabled == True
+        assert tps.enabled is True
 
     def test_init_transforms_name(self):
         tps = TransmitPortSetting(1234, 8080, True)

--- a/tests/test_setting.py
+++ b/tests/test_setting.py
@@ -1,0 +1,38 @@
+import pytest
+
+from oscduplicator.setting import TransmitPortSetting
+
+
+class TestTransmitPortSetting:
+    def test_init_valid():
+        tps = TransmitPortSetting("Test", 8080, True)
+        assert tps.name == "Test"
+        assert tps.port == 8080
+        assert tps.enabled == True
+
+    def test_init_transforms_name():
+        tps = TransmitPortSetting(1234, 8080, True)
+        assert tps.name == "1234"
+
+    def test_invalid_port_raises_exception():
+        with pytest.raises(ValueError):
+            TransmitPortSetting("Test", 70000, True)
+
+    def test_invalid_enabled_raises_exception():
+        with pytest.raises(TypeError):
+            TransmitPortSetting("Test", 8080, "True")
+
+    def test_set_invalid_port_raises_exception():
+        tps = TransmitPortSetting("Test", 8080, True)
+        with pytest.raises(ValueError):
+            tps.port = 70000
+
+    def test_set_invalid_enabled_raises_exception():
+        tps = TransmitPortSetting("Test", 8080, True)
+        with pytest.raises(TypeError):
+            tps.enabled = "True"
+
+    def test_set_transforms_name():
+        tps = TransmitPortSetting("Test", 8080, True)
+        tps.name = 1234
+        assert tps.name == "1234"

--- a/tests/test_setting.py
+++ b/tests/test_setting.py
@@ -4,35 +4,35 @@ from oscduplicator.setting import TransmitPortSetting
 
 
 class TestTransmitPortSetting:
-    def test_init_valid():
+    def test_init_valid(self):
         tps = TransmitPortSetting("Test", 8080, True)
         assert tps.name == "Test"
         assert tps.port == 8080
         assert tps.enabled == True
 
-    def test_init_transforms_name():
+    def test_init_transforms_name(self):
         tps = TransmitPortSetting(1234, 8080, True)
         assert tps.name == "1234"
 
-    def test_invalid_port_raises_exception():
+    def test_invalid_port_raises_exception(self):
         with pytest.raises(ValueError):
             TransmitPortSetting("Test", 70000, True)
 
-    def test_invalid_enabled_raises_exception():
+    def test_invalid_enabled_raises_exception(self):
         with pytest.raises(TypeError):
             TransmitPortSetting("Test", 8080, "True")
 
-    def test_set_invalid_port_raises_exception():
+    def test_set_invalid_port_raises_exception(self):
         tps = TransmitPortSetting("Test", 8080, True)
         with pytest.raises(ValueError):
             tps.port = 70000
 
-    def test_set_invalid_enabled_raises_exception():
+    def test_set_invalid_enabled_raises_exception(self):
         tps = TransmitPortSetting("Test", 8080, True)
         with pytest.raises(TypeError):
             tps.enabled = "True"
 
-    def test_set_transforms_name():
+    def test_set_transforms_name(self):
         tps = TransmitPortSetting("Test", 8080, True)
         tps.name = 1234
         assert tps.name == "1234"

--- a/tests/tests_Settings.json
+++ b/tests/tests_Settings.json
@@ -1,0 +1,27 @@
+{
+    "receive": [
+        {"port": 9001}
+    ],
+    "transmit": [
+        {
+            "name": "test1_t",
+            "port": 9001,
+            "ebable": true
+        },
+        {
+            "name": "test2_t",
+            "port": 9002,
+            "ebable": true
+        },
+        {
+            "name": "test3_f",
+            "port": 9003,
+            "ebable": false
+        },
+        {
+            "name": "test3_f",
+            "port": 9003,
+            "ebable": false
+        }
+    ]
+}


### PR DESCRIPTION
OSCを再分配するduplicator.pyとその単体テスト、統合テストの実装が完了しました。

osc_serverを立てるときに"127.0.0.1"を使用していましたが、それではうまくいかず、"0.0.0.0"を使用したらうまくいきました。なぜでしょうか？

また、統合テストの中身については検討する必要があるかと思われます。

ご確認ください。