### PR TITLE
fletを0.7.4に更新する

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flet==0.5.0
+flet==0.7.4
 python-osc==1.8.1


### PR DESCRIPTION
flet v0.6.0 で導入された [Rich text](https://flet.dev/docs/controls/text/#spans) を使えると良さそうなので、fletを更新します。

[CHANGELOG](https://github.com/flet-dev/flet/blob/v0.7.4/CHANGELOG.md#074)