### PR TITLE
OSCReceiverのリファクタリング

### DIFF
--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from queue import Queue
 
 from oscduplicator.osc_receiver import OSCReceiver
 from oscduplicator.settings import Settings
@@ -24,8 +25,9 @@ class Duplicator:
 
     def __init__(self) -> None:
         self.settings = Settings(Duplicator.FILE_PATH)
-        self.receiver = OSCReceiver(self.settings.receive_port)
-        self.transmitter = OSCTransmitter(self.receiver.q)
+        queue = Queue()
+        self.receiver = OSCReceiver(self.settings.receive_port, queue)
+        self.transmitter = OSCTransmitter(queue)
         self.is_duplicate = False
 
     def start_duplicate(self, receive_port, transmit_port_settings):

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -44,12 +44,12 @@ class Duplicator:
         self.__update_settings(receive_port, transmit_port_settings)
 
         self.receiver.receive_port = self.settings.receive_port
-        self.receiver.init_server()
+        self.receiver._create_server()
 
         self.transmitter.transmit_ports = self.settings.get_transmit_ports()
         self.transmitter.init_clients(self.transmitter.transmit_ports)
 
-        self.receiver.start_receiver()
+        self.receiver.start()
         self.transmitter.start_transmitter()
 
         self.is_duplicate = True
@@ -58,7 +58,7 @@ class Duplicator:
         """
         On stop button pushed
         """
-        self.receiver.stop_receiver()
+        self.receiver.stop()
         self.transmitter.stop_transmitter()
 
         self.is_duplicate = False

--- a/oscduplicator/osc_receiver.py
+++ b/oscduplicator/osc_receiver.py
@@ -29,32 +29,32 @@ class OSCReceiver:
 
     def __init__(self, receive_port: int, message_queue: Queue) -> None:
         self.receive_port: int = receive_port
-        self.server: BlockingOSCUDPServer = self.init_server()
+        self.server: BlockingOSCUDPServer = self._create_server()
         self._message_queue = message_queue
 
-    def init_server(self):
+    def _create_server(self):
         """
-        OSCサーバーを初期化
+        OSCサーバーを作成する
         """
         dpt = Dispatcher()
-        dpt.map("*", self.q_put)
+        dpt.map("*", self.message_handler)
 
         return BlockingOSCUDPServer(("0, 0, 0, 0", self.receive_port), dpt)
 
-    def start_receiver(self):
+    def start(self):
         """
         OSCReceiverを起動する
         """
         th = Thread(target=self.server.serve_forever)
         th.start()
 
-    def stop_receiver(self):
+    def stop(self):
         """
         OSCReceiverを終了する
         """
         self.server.shutdown()
 
-    def q_put(self, address: str, args: list[Any]):
+    def message_handler(self, address: str, args: list[Any]):
         """
         受信したOSC messageとaddressをQueueに追加する
         """

--- a/oscduplicator/osc_receiver.py
+++ b/oscduplicator/osc_receiver.py
@@ -23,14 +23,14 @@ class OSCReceiver:
         OSC信号を受信するためのポート番号
     server: BlockingOSCUDPServer
         OSC信号を受信するためのサーバー
-    q: Queue
+    _message_queue: Queue
         受信したOSC messageを格納するキュー
     """
 
-    def __init__(self, receive_port: int) -> None:
+    def __init__(self, receive_port: int, message_queue: Queue) -> None:
         self.receive_port: int = receive_port
         self.server: BlockingOSCUDPServer = self.init_server()
-        self.q = Queue()
+        self._message_queue = message_queue
 
     def init_server(self):
         """
@@ -59,4 +59,4 @@ class OSCReceiver:
         受信したOSC messageとaddressをQueueに追加する
         """
         osc_message = OSCMessage(address, args)
-        self.q.put(osc_message)
+        self._message_queue.put(osc_message)

--- a/tests/test_osc_receiver.py
+++ b/tests/test_osc_receiver.py
@@ -1,20 +1,16 @@
 import unittest.mock as mock
-from queue import Empty, Queue
-import pytest
+from queue import Queue
 
 from oscduplicator.osc_receiver import OSCReceiver
 
 
 def test_init():
-    with mock.patch(
-        "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
-    ) as mock_server:
-        queue = Queue()
-        receiver = OSCReceiver(5000, queue)
+    queue = Queue()
+    receiver = OSCReceiver(5000, queue)
 
-        assert receiver.receive_port == 5000
-        assert receiver.server is mock_server.return_value
-        assert receiver._message_queue is queue
+    assert receiver.receive_port == 5000
+    assert receiver._server is None
+    assert receiver._message_queue is queue
 
 
 def test_start():
@@ -33,28 +29,26 @@ def test_start():
 
 
 def test_stop():
-    with mock.patch(
-        "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
-    ) as mock_server:
-        receiver = OSCReceiver(5000, Queue())
-        receiver.stop()
+    receiver = OSCReceiver(5000, Queue())
 
-        mock_server.return_value.shutdown.assert_called_once()
+    receiver._server = None
+    receiver.stop()  # start前に呼ばれてもエラーにならない
+
+    receiver._server = mock_server = mock.Mock()
+    receiver.stop()
+    mock_server.shutdown.assert_called_once()
 
 
 def test_message_handler():
-    with mock.patch(
-        "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
-    ):
-        receiver = OSCReceiver(5000, Queue())
-        address = "/test"
-        args = ["message"]
-        receiver.message_handler(address, args)
+    queue = Queue()
+    receiver = OSCReceiver(5000, queue)
+    address = "/test"
+    args = ["message"]
+    receiver.message_handler(address, args)
 
-        try:
-            message = receiver._message_queue.get_nowait()
-        except Empty:
-            pytest.fail("Queue should not be empty")
+    assert queue.qsize() == 1
 
-        assert message.address == address
-        assert message.message == args
+    message = receiver._message_queue.get_nowait()
+
+    assert message.address == address
+    assert message.message == args

--- a/tests/test_osc_receiver.py
+++ b/tests/test_osc_receiver.py
@@ -5,7 +5,7 @@ import pytest
 from oscduplicator.osc_receiver import OSCReceiver
 
 
-def test_osc_receiver_init():
+def test_init():
     with mock.patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
     ) as mock_server:
@@ -17,14 +17,14 @@ def test_osc_receiver_init():
         assert receiver._message_queue is queue
 
 
-def test_start_receiver():
+def test_start():
     with mock.patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
     ) as mock_server, mock.patch(
         "oscduplicator.osc_receiver.Thread", autospec=True
     ) as mock_thread:
         receiver = OSCReceiver(5000, Queue())
-        receiver.start_receiver()
+        receiver.start()
 
         mock_thread.assert_called_once_with(
             target=mock_server.return_value.serve_forever
@@ -32,24 +32,24 @@ def test_start_receiver():
         mock_thread.return_value.start.assert_called_once()
 
 
-def test_stop_receiver():
+def test_stop():
     with mock.patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
     ) as mock_server:
         receiver = OSCReceiver(5000, Queue())
-        receiver.stop_receiver()
+        receiver.stop()
 
         mock_server.return_value.shutdown.assert_called_once()
 
 
-def test_q_put():
+def test_message_handler():
     with mock.patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
     ):
         receiver = OSCReceiver(5000, Queue())
         address = "/test"
         args = ["message"]
-        receiver.q_put(address, args)
+        receiver.message_handler(address, args)
 
         try:
             message = receiver._message_queue.get_nowait()

--- a/tests/test_osc_receiver.py
+++ b/tests/test_osc_receiver.py
@@ -1,5 +1,5 @@
 import unittest.mock as mock
-from queue import Empty
+from queue import Empty, Queue
 import pytest
 
 from oscduplicator.osc_receiver import OSCReceiver
@@ -9,11 +9,12 @@ def test_osc_receiver_init():
     with mock.patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
     ) as mock_server:
-        receiver = OSCReceiver(5000)
+        queue = Queue()
+        receiver = OSCReceiver(5000, queue)
 
         assert receiver.receive_port == 5000
         assert receiver.server is mock_server.return_value
-        assert receiver.q.empty()
+        assert receiver._message_queue is queue
 
 
 def test_start_receiver():
@@ -22,7 +23,7 @@ def test_start_receiver():
     ) as mock_server, mock.patch(
         "oscduplicator.osc_receiver.Thread", autospec=True
     ) as mock_thread:
-        receiver = OSCReceiver(5000)
+        receiver = OSCReceiver(5000, Queue())
         receiver.start_receiver()
 
         mock_thread.assert_called_once_with(
@@ -35,7 +36,7 @@ def test_stop_receiver():
     with mock.patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
     ) as mock_server:
-        receiver = OSCReceiver(5000)
+        receiver = OSCReceiver(5000, Queue())
         receiver.stop_receiver()
 
         mock_server.return_value.shutdown.assert_called_once()
@@ -45,13 +46,13 @@ def test_q_put():
     with mock.patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
     ):
-        receiver = OSCReceiver(5000)
+        receiver = OSCReceiver(5000, Queue())
         address = "/test"
         args = ["message"]
         receiver.q_put(address, args)
 
         try:
-            message = receiver.q.get_nowait()
+            message = receiver._message_queue.get_nowait()
         except Empty:
             pytest.fail("Queue should not be empty")
 

--- a/tests/test_osc_receiver.py
+++ b/tests/test_osc_receiver.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+from unittest.mock import Mock, patch
 from queue import Queue
 
 from oscduplicator.osc_receiver import OSCReceiver
@@ -14,9 +14,9 @@ def test_init():
 
 
 def test_start():
-    with mock.patch(
+    with patch(
         "oscduplicator.osc_receiver.BlockingOSCUDPServer", autospec=True
-    ) as mock_server, mock.patch(
+    ) as mock_server, patch(
         "oscduplicator.osc_receiver.Thread", autospec=True
     ) as mock_thread:
         receiver = OSCReceiver(5000, Queue())
@@ -34,7 +34,7 @@ def test_stop():
     receiver._server = None
     receiver.stop()  # start前に呼ばれてもエラーにならない
 
-    receiver._server = mock_server = mock.Mock()
+    receiver._server = mock_server = Mock()
     receiver.stop()
     mock_server.shutdown.assert_called_once()
 


### PR DESCRIPTION
* メッセージキューオブジェクトは、Duplicator管理にしました
* OSCサーバーは、Receiverが内部的に管理するようにしました
* BlockingOSCUDPServer のモック使用を最小限にしました
* 起動/終了 を `receiver.start()` / `receiver.stop()` にしました