### PR TITLE
OSCTransmitterの改修

### DIFF
--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -48,10 +48,10 @@ class Duplicator:
         self.receiver = OSCReceiver(self.settings.receive_port, self.queue)
 
         self.transmitter.transmit_ports = self.settings.get_transmit_ports()
-        self.transmitter.init_clients(self.transmitter.transmit_ports)
+        self.transmitter.create_clients(self.transmitter.transmit_ports)
 
         self.receiver.start()
-        self.transmitter.start_transmitter()
+        self.transmitter.start()
 
         self.is_duplicate = True
 
@@ -62,7 +62,7 @@ class Duplicator:
         if self.receiver:
             self.receiver.stop()
 
-        self.transmitter.stop_transmitter()
+        self.transmitter.stop()
 
         self.is_duplicate = False
 

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -47,8 +47,9 @@ class Duplicator:
 
         self.receiver = OSCReceiver(self.settings.receive_port, self.queue)
 
-        self.transmitter.transmit_ports = self.settings.get_transmit_ports()
-        self.transmitter.create_clients(self.transmitter.transmit_ports)
+        transmit_ports = self.settings.get_transmit_ports()
+        for port in transmit_ports:
+            self.transmitter.add_destination_port(port)
 
         self.receiver.start()
         self.transmitter.start()
@@ -62,7 +63,7 @@ class Duplicator:
         if self.receiver:
             self.receiver.stop()
 
-        self.transmitter.stop()
+        self.transmitter.pause()
 
         self.is_duplicate = False
 

--- a/oscduplicator/osc_transmitter.py
+++ b/oscduplicator/osc_transmitter.py
@@ -1,6 +1,5 @@
-from threading import Thread
+from threading import Thread, Lock
 from queue import Queue
-import socket
 
 from pythonosc.udp_client import SimpleUDPClient
 
@@ -8,61 +7,42 @@ from oscduplicator.osc_receiver import OSCMessage
 
 
 class OSCTransmitter:
-    """
-    QueueからOSC messageを取り出し、各ポートへ転送する
+    ADDRESS = "127.0.0.1"
 
-    Attributes
-    ---------
-    transmit_ports: list[int]
-        OSC信号を再送信するための、portのリスト
-    clients: list[SimpleUDPClient]
-        OSC信号を再送信するための、clientのリスト
-    q: Queue
-        OSC信号の受信順・送信順を保証するためのキュー
-    is_shutdown: bool
-        transmitterを停止するためのフラグ
+    def __init__(self, q: Queue[OSCMessage]) -> None:
+        self._q = q
+        self._clients: dict[int, SimpleUDPClient] = {}
+        self._clients_lock = Lock()
+        self._thread = Thread(target=self._loop, daemon=True)
+        self._thread.start()
+        self._running = False
 
-    """
+    def start(self) -> None:
+        self._running = True
 
-    def __init__(self, q: Queue) -> None:
-        self.transmit_ports: list[int] = []
-        self._q: Queue = q
-        self.clients: list[SimpleUDPClient] = self.create_clients(
-            self.transmit_ports
-        )
-        self.is_shutdown = False
+    def pause(self) -> None:
+        self._running = False
 
-    def create_clients(self, transmit_ports):
-        """
-        OSCクライエントを初期化
-        """
+    def _loop(self) -> None:
+        while True:
+            message = self._q.get()
+            if self._running:
+                self._transmit(message)
 
-        def __client(port: int) -> SimpleUDPClient:
-            hostname = socket.gethostname()
-            ip = socket.gethostbyname(hostname)
-            str_ip = str(ip)
-            return SimpleUDPClient(str_ip, port)
+    def _transmit(self, message: OSCMessage):
+        for client in self._clients.values():
+            client.send_message(message.address, message.message)
 
-        return [__client(i) for i in transmit_ports]
+    def add_destination_port(self, port: int) -> bool:
+        with self._clients_lock:
+            if port not in self._clients:
+                self._clients[port] = SimpleUDPClient(OSCTransmitter.ADDRESS,
+                                                      port)
+                return True
+            else:
+                return False
 
-    def start(self):
-        thread = Thread(target=self._transmit_forever)
-        thread.start()
-
-    def stop(self):
-        self.is_shutdown = True
-
-    def _transmit_forever(self):
-        self.is_shutdown = False
-
-        while not self.is_shutdown:
-            self._transmit_message(self._q, self.clients)
-
-    def _transmit_message(self, q: Queue, clients: list[SimpleUDPClient]):
-        if not clients:
-            osc_message: OSCMessage = q.get()
-
-            for client in clients:
-                client.send_message(osc_message.address, osc_message.message)
-
-            q.task_done()
+    def remove_destination_port(self, port: int) -> None:
+        with self._clients_lock:
+            if port in self._clients:
+                del self._clients[port]

--- a/oscduplicator/osc_transmitter.py
+++ b/oscduplicator/osc_transmitter.py
@@ -26,7 +26,7 @@ class OSCTransmitter:
 
     def __init__(self, q: Queue) -> None:
         self.transmit_ports: list[int] = []
-        self.__q: Queue = q
+        self._q: Queue = q
         self.clients: list[SimpleUDPClient] = self.init_clients(
             self.transmit_ports
         )
@@ -56,7 +56,7 @@ class OSCTransmitter:
         self.is_shutdown = False
 
         while not self.is_shutdown:
-            self.transmit_message(self.__q, self.clients)
+            self.transmit_message(self._q, self.clients)
 
     def transmit_message(self, q: Queue, clients: list[SimpleUDPClient]):
         if not clients:

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -1,41 +1,43 @@
-import pytest
-from unittest.mock import patch
 from queue import Queue
+from unittest.mock import patch
+
 from pythonosc.udp_client import SimpleUDPClient
+
 from oscduplicator.osc_transmitter import OSCTransmitter
 
 
-class TestOSCTransmitter:
-    @pytest.fixture
-    def transmitter(self):
-        q = Queue()
-        transmitter = OSCTransmitter(q)
-        return transmitter
+def test_init():
+    queue = Queue()
+    transmitter = OSCTransmitter(queue)
+    assert transmitter._q is queue
+    assert not transmitter.is_shutdown
+    assert len(transmitter.clients) == 0
 
-    def test_init(self, transmitter):
-        assert transmitter._OSCTransmitter__q.empty()
-        assert not transmitter.is_shutdown
-        assert transmitter.clients == []
 
-    def test_init_clients(self, transmitter):
-        with patch(
-            "oscduplicator.osc_transmitter.socket.gethostname",
-            return_value="localhost",
-        ), patch(
-            "oscduplicator.osc_transmitter.socket.gethostbyname",
-            return_value="127.0.0.1",
-        ):
-            transmitter.transmit_ports = [8000, 8001]
-            clients = transmitter.init_clients(transmitter.transmit_ports)
-            assert len(clients) == 2
-            for client in clients:
-                assert isinstance(client, SimpleUDPClient)
+def test_init_clients():
+    transmitter = OSCTransmitter(Queue())
+    with patch(
+        "oscduplicator.osc_transmitter.socket.gethostname",
+        return_value="localhost",
+    ), patch(
+        "oscduplicator.osc_transmitter.socket.gethostbyname",
+        return_value="127.0.0.1",
+    ):
+        transmitter.transmit_ports = [8000, 8001]
+        clients = transmitter.init_clients(transmitter.transmit_ports)
+        assert len(clients) == 2
+        for client in clients:
+            assert isinstance(client, SimpleUDPClient)
 
-    def test_start_transmitter(self, transmitter):
-        with patch("oscduplicator.osc_transmitter.Thread.start") as mock_start:
-            transmitter.start_transmitter()
-            mock_start.assert_called_once()
 
-    def test_stop_transmitter(self, transmitter):
-        transmitter.stop_transmitter()
-        assert transmitter.is_shutdown
+def test_start_transmitter():
+    transmitter = OSCTransmitter(Queue())
+    with patch("oscduplicator.osc_transmitter.Thread.start") as mock_start:
+        transmitter.start_transmitter()
+        mock_start.assert_called_once()
+
+
+def test_stop_transmitter():
+    transmitter = OSCTransmitter(Queue())
+    transmitter.stop_transmitter()
+    assert transmitter.is_shutdown

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -14,7 +14,7 @@ def test_init():
     assert len(transmitter.clients) == 0
 
 
-def test_init_clients():
+def test_create_clients():
     transmitter = OSCTransmitter(Queue())
     with patch(
         "oscduplicator.osc_transmitter.socket.gethostname",
@@ -24,20 +24,20 @@ def test_init_clients():
         return_value="127.0.0.1",
     ):
         transmitter.transmit_ports = [8000, 8001]
-        clients = transmitter.init_clients(transmitter.transmit_ports)
+        clients = transmitter.create_clients(transmitter.transmit_ports)
         assert len(clients) == 2
         for client in clients:
             assert isinstance(client, SimpleUDPClient)
 
 
-def test_start_transmitter():
+def test_start():
     transmitter = OSCTransmitter(Queue())
     with patch("oscduplicator.osc_transmitter.Thread.start") as mock_start:
-        transmitter.start_transmitter()
+        transmitter.start()
         mock_start.assert_called_once()
 
 
-def test_stop_transmitter():
+def test_stop():
     transmitter = OSCTransmitter(Queue())
-    transmitter.stop_transmitter()
+    transmitter.stop()
     assert transmitter.is_shutdown

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -1,43 +1,89 @@
 from queue import Queue
-from unittest.mock import patch
+import time
+from unittest.mock import Mock
 
-from pythonosc.udp_client import SimpleUDPClient
-
+from oscduplicator.osc_receiver import OSCMessage
 from oscduplicator.osc_transmitter import OSCTransmitter
 
 
 def test_init():
     queue = Queue()
     transmitter = OSCTransmitter(queue)
-    assert transmitter._q is queue
-    assert not transmitter.is_shutdown
-    assert len(transmitter.clients) == 0
+    transmitter.start()
+    transmitter._clients[9000] = mock_client = Mock()
 
+    queue.put(OSCMessage("/test", 1))
+    time.sleep(0.1)
+    mock_client.send_message.assert_called_once_with("/test", 1)
+    mock_client.reset_mock()
 
-def test_create_clients():
-    transmitter = OSCTransmitter(Queue())
-    with patch(
-        "oscduplicator.osc_transmitter.socket.gethostname",
-        return_value="localhost",
-    ), patch(
-        "oscduplicator.osc_transmitter.socket.gethostbyname",
-        return_value="127.0.0.1",
-    ):
-        transmitter.transmit_ports = [8000, 8001]
-        clients = transmitter.create_clients(transmitter.transmit_ports)
-        assert len(clients) == 2
-        for client in clients:
-            assert isinstance(client, SimpleUDPClient)
+    transmitter.pause()
+
+    queue.put(OSCMessage("/test", 2))
+    time.sleep(0.1)
+    mock_client.send_message.assert_not_called()
+    mock_client.reset_mock()
 
 
 def test_start():
     transmitter = OSCTransmitter(Queue())
-    with patch("oscduplicator.osc_transmitter.Thread.start") as mock_start:
-        transmitter.start()
-        mock_start.assert_called_once()
+    transmitter.start()
+    assert transmitter._running is True
 
 
-def test_stop():
+def test_pause():
     transmitter = OSCTransmitter(Queue())
-    transmitter.stop()
-    assert transmitter.is_shutdown
+    transmitter.start()
+    transmitter.pause()
+    assert transmitter._running is False
+
+
+def test_add_destination_port():
+    transmitter = OSCTransmitter(Queue())
+
+    # Add a new port
+    port1 = 8000
+    assert transmitter.add_destination_port(port1) is True
+
+    # Add the same port again
+    assert transmitter.add_destination_port(port1) is False
+
+    # Add a different port
+    port2 = 9000
+    assert transmitter.add_destination_port(port2) is True
+
+    # Check if the clients dictionary is updated correctly
+    assert port1 in transmitter._clients
+    assert port2 in transmitter._clients
+    assert len(transmitter._clients) == 2
+
+    # Check if the SimpleUDPClient instances are created correctly
+    assert transmitter._clients[port1]._address == OSCTransmitter.ADDRESS
+    assert transmitter._clients[port1]._port == port1
+    assert transmitter._clients[port2]._address == OSCTransmitter.ADDRESS
+    assert transmitter._clients[port2]._port == port2
+
+
+def test_remove_destination_port():
+    transmitter = OSCTransmitter(Queue())
+
+    # Add ports
+    port1 = 8000
+    port2 = 9000
+    transmitter.add_destination_port(port1)
+    transmitter.add_destination_port(port2)
+    assert len(transmitter._clients) == 2
+
+    # Remove a port that exists
+    transmitter.remove_destination_port(port1)
+    assert port1 not in transmitter._clients
+    assert len(transmitter._clients) == 1
+
+    # Remove a port that doesn't exist
+    non_existing_port = 10000
+    #   Should not raise an error
+    transmitter.remove_destination_port(non_existing_port)
+    assert len(transmitter._clients) == 1
+
+    # Check if the other port still exists
+    assert port2 in transmitter._clients


### PR DESCRIPTION
* Transmitterは常にQueueから `get` するようにしました（Queueを詰まらせないため）
* 動的に宛先ポートを追加・削除できるようにしました
* Lock を使用し、追加・削除・送信 がいずれも同時に発生しないよう制限しました