### PR TITLE
編集用ダイアログのレイアウトの作成

### DIFF
--- a/oscduplicator/gui/app.py
+++ b/oscduplicator/gui/app.py
@@ -19,9 +19,9 @@ class App:
                             controls=[
                                 ft.TextField(label="port", width=100),
                             ]
-                        )
+                        ),
                     ],
-                    height=100
+                    height=100,
                 ),
                 actions=[
                     ft.TextButton("確定", on_click=close_dlg),
@@ -42,9 +42,9 @@ class App:
                                 ft.TextField(label="port", width=100),
                                 ft.TextField(label="name", width=100),
                             ]
-                        )
+                        ),
                     ],
-                    height=100
+                    height=100,
                 ),
                 actions=[
                     ft.TextButton("確定", on_click=close_dlg),
@@ -54,7 +54,7 @@ class App:
             )
             page.dialog.open = True
             page.update()
-        
+
         def close_dlg(_):
             page.dialog.open = False
             page.update()
@@ -64,8 +64,12 @@ class App:
         page.window_width, page.window_height = 600, 800
 
         self.header = Header()
-        self.receiver_container = ReceiverContainer(9001, show_receiver_edit_dlg)  # ポートは仮
-        self.transmitter_container = TransmitterContainer(show_transmitter_edit_dlg)
+        self.receiver_container = ReceiverContainer(
+            9001, show_receiver_edit_dlg
+        )  # ポートは仮
+        self.transmitter_container = TransmitterContainer(
+            show_transmitter_edit_dlg
+        )
 
         page.add(self.header)
         page.add(self.receiver_container)

--- a/oscduplicator/gui/app.py
+++ b/oscduplicator/gui/app.py
@@ -10,13 +10,62 @@ APP_TITLE = "OSCDuplicator"
 
 class App:
     def main(self, page: ft.Page):
+        def show_receiver_edit_dlg(_):
+            page.dialog = ft.AlertDialog(
+                content=ft.Column(
+                    controls=[
+                        ft.Text("受信設定"),
+                        ft.Row(
+                            controls=[
+                                ft.TextField(label="port", width=100),
+                            ]
+                        )
+                    ],
+                    height=100
+                ),
+                actions=[
+                    ft.TextButton("確定", on_click=close_dlg),
+                    ft.TextButton("キャンセル", on_click=close_dlg),
+                ],
+                actions_alignment=ft.MainAxisAlignment.END,
+            )
+            page.dialog.open = True
+            page.update()
+
+        def show_transmitter_edit_dlg(_):
+            page.dialog = ft.AlertDialog(
+                content=ft.Column(
+                    controls=[
+                        ft.Text("転送設定"),
+                        ft.Row(
+                            controls=[
+                                ft.TextField(label="port", width=100),
+                                ft.TextField(label="name", width=100),
+                            ]
+                        )
+                    ],
+                    height=100
+                ),
+                actions=[
+                    ft.TextButton("確定", on_click=close_dlg),
+                    ft.TextButton("キャンセル", on_click=close_dlg),
+                ],
+                actions_alignment=ft.MainAxisAlignment.END,
+            )
+            page.dialog.open = True
+            page.update()
+        
+        def close_dlg(_):
+            page.dialog.open = False
+            page.update()
+
         page.title = APP_TITLE
         page.horizontal_alignment = "center"
         page.window_width, page.window_height = 600, 800
 
         self.header = Header()
-        self.receiver_container = ReceiverContainer(9001)  # ポートは仮
-        self.transmitter_container = TransmitterContainer()
+        self.receiver_container = ReceiverContainer(9001, show_receiver_edit_dlg)  # ポートは仮
+        self.transmitter_container = TransmitterContainer(show_transmitter_edit_dlg)
 
         page.add(self.header)
         page.add(self.receiver_container)

--- a/oscduplicator/gui/app.py
+++ b/oscduplicator/gui/app.py
@@ -10,66 +10,13 @@ APP_TITLE = "OSCDuplicator"
 
 class App:
     def main(self, page: ft.Page):
-        def show_receiver_edit_dlg(_):
-            page.dialog = ft.AlertDialog(
-                content=ft.Column(
-                    controls=[
-                        ft.Text("受信設定"),
-                        ft.Row(
-                            controls=[
-                                ft.TextField(label="port", width=100),
-                            ]
-                        ),
-                    ],
-                    height=100,
-                ),
-                actions=[
-                    ft.TextButton("確定", on_click=close_dlg),
-                    ft.TextButton("キャンセル", on_click=close_dlg),
-                ],
-                actions_alignment=ft.MainAxisAlignment.END,
-            )
-            page.dialog.open = True
-            page.update()
-
-        def show_transmitter_edit_dlg(_):
-            page.dialog = ft.AlertDialog(
-                content=ft.Column(
-                    controls=[
-                        ft.Text("転送設定"),
-                        ft.Row(
-                            controls=[
-                                ft.TextField(label="port", width=100),
-                                ft.TextField(label="name", width=100),
-                            ]
-                        ),
-                    ],
-                    height=100,
-                ),
-                actions=[
-                    ft.TextButton("確定", on_click=close_dlg),
-                    ft.TextButton("キャンセル", on_click=close_dlg),
-                ],
-                actions_alignment=ft.MainAxisAlignment.END,
-            )
-            page.dialog.open = True
-            page.update()
-
-        def close_dlg(_):
-            page.dialog.open = False
-            page.update()
-
         page.title = APP_TITLE
         page.horizontal_alignment = "center"
         page.window_width, page.window_height = 600, 800
 
         self.header = Header()
-        self.receiver_container = ReceiverContainer(
-            9001, show_receiver_edit_dlg
-        )  # ポートは仮
-        self.transmitter_container = TransmitterContainer(
-            show_transmitter_edit_dlg
-        )
+        self.receiver_container = ReceiverContainer(9001)  # ポートは仮
+        self.transmitter_container = TransmitterContainer()
 
         page.add(self.header)
         page.add(self.receiver_container)

--- a/oscduplicator/gui/receiver_container.py
+++ b/oscduplicator/gui/receiver_container.py
@@ -16,7 +16,7 @@ class ReceiverContainer(ft.UserControl):
 
     def build(self):
         self.edit_button = ft.ElevatedButton(
-            text="編集", on_click=self.show_receiver_edit_dlg
+            text="編集", on_click=self.show_receiver_edit_dialog
         )
 
         return ft.Container(
@@ -33,7 +33,7 @@ class ReceiverContainer(ft.UserControl):
             ),
         )
 
-    def show_receiver_edit_dlg(self, e):
+    def show_receiver_edit_dialog(self, e):
         e.page.dialog = ft.AlertDialog(
             content=ft.Column(
                 controls=[
@@ -47,14 +47,14 @@ class ReceiverContainer(ft.UserControl):
                 height=100,
             ),
             actions=[
-                ft.TextButton("確定", on_click=self.close_dlg),
-                ft.TextButton("キャンセル", on_click=self.close_dlg),
+                ft.TextButton("確定", on_click=self.close_dialog),
+                ft.TextButton("キャンセル", on_click=self.close_dialog),
             ],
             actions_alignment=ft.MainAxisAlignment.END,
         )
         e.page.dialog.open = True
         e.page.update()
 
-    def close_dlg(self, e):  # 仮
+    def close_dialog(self, e):  # 仮
         e.page.dialog.open = False
         e.page.update()

--- a/oscduplicator/gui/receiver_container.py
+++ b/oscduplicator/gui/receiver_container.py
@@ -12,14 +12,13 @@ class ReceiverContainer(ft.UserControl):
         page.dialog
     """
 
-    def __init__(self, receive_port, on_edit_button_clicked):
+    def __init__(self, receive_port):
         super().__init__()
         self.receive_port = receive_port
-        self.on_edit_button_clicked = on_edit_button_clicked
 
     def build(self):
         self.edit_button = ft.ElevatedButton(
-            text="編集", on_click=self.on_edit_button_clicked
+            text="編集", on_click=self.show_receiver_edit_dlg
         )
 
         return ft.Container(
@@ -35,3 +34,30 @@ class ReceiverContainer(ft.UserControl):
                 ]
             ),
         )
+
+    def show_receiver_edit_dlg(self, e):
+        e.page.dialog = ft.AlertDialog(
+            content=ft.Column(
+                controls=[
+                    ft.Text("受信設定"),
+                    ft.Row(
+                        controls=[
+                            ft.TextField(label="port", width=100),
+                        ]
+                    ),
+                ],
+                height=100,
+            ),
+            actions=[
+                ft.TextButton("確定", on_click=self.close_dlg),
+                ft.TextButton("キャンセル", on_click=self.close_dlg),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        print(type(e))
+        e.page.dialog.open = True
+        e.page.update()
+
+    def close_dlg(self, e):  # 仮
+        e.page.dialog.open = False
+        e.page.update()

--- a/oscduplicator/gui/receiver_container.py
+++ b/oscduplicator/gui/receiver_container.py
@@ -54,7 +54,6 @@ class ReceiverContainer(ft.UserControl):
             ],
             actions_alignment=ft.MainAxisAlignment.END,
         )
-        print(type(e))
         e.page.dialog.open = True
         e.page.update()
 

--- a/oscduplicator/gui/receiver_container.py
+++ b/oscduplicator/gui/receiver_container.py
@@ -8,8 +8,6 @@ class ReceiverContainer(ft.UserControl):
     Attribute
     ---------
     receive_port: int
-    page_dialog: Control
-        page.dialog
     """
 
     def __init__(self, receive_port):

--- a/oscduplicator/gui/receiver_container.py
+++ b/oscduplicator/gui/receiver_container.py
@@ -8,11 +8,14 @@ class ReceiverContainer(ft.UserControl):
     Attribute
     ---------
     receive_port: int
+    page_dialog: Control
+        page.dialog
     """
 
-    def __init__(self, receive_port):
+    def __init__(self, receive_port, on_edit_button_clicked):
         super().__init__()
         self.receive_port = receive_port
+        self.on_edit_button_clicked = on_edit_button_clicked
 
     def build(self):
         self.edit_button = ft.ElevatedButton(
@@ -32,6 +35,3 @@ class ReceiverContainer(ft.UserControl):
                 ]
             ),
         )
-
-    def on_edit_button_clicked(self):
-        pass

--- a/oscduplicator/gui/transmitter_container.py
+++ b/oscduplicator/gui/transmitter_container.py
@@ -30,6 +30,7 @@ class TransmitterContainer(ft.UserControl):
                             ft.DataColumn(ft.Text("名前")),
                             ft.DataColumn(ft.Text("有効化")),
                             ft.DataColumn(ft.Text("")),
+                            ft.DataColumn(ft.Text("")),
                         ],
                         rows=self.data_table_rows(),
                     ),
@@ -60,6 +61,7 @@ class TransmitterContainer(ft.UserControl):
                             text="編集", on_click=self.show_transmitter_edit_dlg
                         )
                     ),
+                    ft.DataCell(ft.IconButton(icon=ft.icons.DELETE_FOREVER)),
                 ]
             )
 

--- a/oscduplicator/gui/transmitter_container.py
+++ b/oscduplicator/gui/transmitter_container.py
@@ -58,8 +58,7 @@ class TransmitterContainer(ft.UserControl):
                     ft.DataCell(ft.Checkbox(value=enabled)),
                     ft.DataCell(
                         ft.ElevatedButton(
-                            text="編集",
-                            on_click= self.on_edit_button_clicked
+                            text="編集", on_click=self.on_edit_button_clicked
                         )
                     ),
                 ]

--- a/oscduplicator/gui/transmitter_container.py
+++ b/oscduplicator/gui/transmitter_container.py
@@ -38,7 +38,7 @@ class TransmitterContainer(ft.UserControl):
                         text="追加",
                         icon=ft.icons.ADD,
                         width=440,
-                        on_click=self.show_transmitter_add_dlg,
+                        on_click=self.show_transmitter_add_dialog,
                     ),
                 ]
             ),
@@ -58,7 +58,8 @@ class TransmitterContainer(ft.UserControl):
                     ft.DataCell(ft.Checkbox(value=enabled)),
                     ft.DataCell(
                         ft.ElevatedButton(
-                            text="編集", on_click=self.show_transmitter_edit_dlg
+                            text="編集",
+                            on_click=self.show_transmitter_edit_dialog,
                         )
                     ),
                     ft.DataCell(ft.IconButton(icon=ft.icons.DELETE_FOREVER)),
@@ -73,7 +74,7 @@ class TransmitterContainer(ft.UserControl):
                 for setting in self.transmitter_settings
             ]
 
-    def show_transmitter_edit_dlg(self, e):
+    def show_transmitter_edit_dialog(self, e):
         e.page.dialog = ft.AlertDialog(
             content=ft.Column(
                 controls=[
@@ -88,15 +89,15 @@ class TransmitterContainer(ft.UserControl):
                 height=100,
             ),
             actions=[
-                ft.TextButton("確定", on_click=self.close_dlg),
-                ft.TextButton("キャンセル", on_click=self.close_dlg),
+                ft.TextButton("確定", on_click=self.close_dialog),
+                ft.TextButton("キャンセル", on_click=self.close_dialog),
             ],
             actions_alignment=ft.MainAxisAlignment.END,
         )
         e.page.dialog.open = True
         e.page.update()
 
-    def show_transmitter_add_dlg(self, e):
+    def show_transmitter_add_dialog(self, e):
         e.page.dialog = ft.AlertDialog(
             content=ft.Column(
                 controls=[
@@ -111,14 +112,14 @@ class TransmitterContainer(ft.UserControl):
                 height=100,
             ),
             actions=[
-                ft.TextButton("追加", on_click=self.close_dlg),
-                ft.TextButton("キャンセル", on_click=self.close_dlg),
+                ft.TextButton("追加", on_click=self.close_dialog),
+                ft.TextButton("キャンセル", on_click=self.close_dialog),
             ],
             actions_alignment=ft.MainAxisAlignment.END,
         )
         e.page.dialog.open = True
         e.page.update()
 
-    def close_dlg(self, e):
+    def close_dialog(self, e):
         e.page.dialog.open = False
         e.page.update()

--- a/oscduplicator/gui/transmitter_container.py
+++ b/oscduplicator/gui/transmitter_container.py
@@ -12,10 +12,9 @@ class TransmitterContainer(ft.UserControl):
 
     """
 
-    def __init__(self, on_edit_button_clicked):
+    def __init__(self):
         super().__init__()
         self.transmitter_settings: list = []
-        self.on_edit_button_clicked = on_edit_button_clicked
 
     def build(self):
         return ft.Container(
@@ -58,7 +57,7 @@ class TransmitterContainer(ft.UserControl):
                     ft.DataCell(ft.Checkbox(value=enabled)),
                     ft.DataCell(
                         ft.ElevatedButton(
-                            text="編集", on_click=self.on_edit_button_clicked
+                            text="編集", on_click=self.show_transmitter_edit_dlg
                         )
                     ),
                 ]
@@ -71,3 +70,30 @@ class TransmitterContainer(ft.UserControl):
                 create_row(setting[0], setting[1], setting[2])
                 for setting in self.transmitter_settings
             ]
+
+    def show_transmitter_edit_dlg(self, e):
+        e.page.dialog = ft.AlertDialog(
+            content=ft.Column(
+                controls=[
+                    ft.Text("転送設定"),
+                    ft.Row(
+                        controls=[
+                            ft.TextField(label="port", width=100),
+                            ft.TextField(label="name", width=100),
+                        ]
+                    ),
+                ],
+                height=100,
+            ),
+            actions=[
+                ft.TextButton("確定", on_click=self.close_dlg),
+                ft.TextButton("キャンセル", on_click=self.close_dlg),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        e.page.dialog.open = True
+        e.page.update()
+
+    def close_dlg(self, e):
+        e.page.dialog.open = False
+        e.page.update()

--- a/oscduplicator/gui/transmitter_container.py
+++ b/oscduplicator/gui/transmitter_container.py
@@ -37,7 +37,7 @@ class TransmitterContainer(ft.UserControl):
                         text="追加",
                         icon=ft.icons.ADD,
                         width=440,
-                        # on_click=
+                        on_click=self.show_transmitter_add_dlg,
                     ),
                 ]
             ),
@@ -87,6 +87,29 @@ class TransmitterContainer(ft.UserControl):
             ),
             actions=[
                 ft.TextButton("確定", on_click=self.close_dlg),
+                ft.TextButton("キャンセル", on_click=self.close_dlg),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        e.page.dialog.open = True
+        e.page.update()
+
+    def show_transmitter_add_dlg(self, e):
+        e.page.dialog = ft.AlertDialog(
+            content=ft.Column(
+                controls=[
+                    ft.Text("転送設定"),
+                    ft.Row(
+                        controls=[
+                            ft.TextField(label="port", width=100),
+                            ft.TextField(label="name", width=100),
+                        ]
+                    ),
+                ],
+                height=100,
+            ),
+            actions=[
+                ft.TextButton("追加", on_click=self.close_dlg),
                 ft.TextButton("キャンセル", on_click=self.close_dlg),
             ],
             actions_alignment=ft.MainAxisAlignment.END,

--- a/oscduplicator/gui/transmitter_container.py
+++ b/oscduplicator/gui/transmitter_container.py
@@ -12,9 +12,10 @@ class TransmitterContainer(ft.UserControl):
 
     """
 
-    def __init__(self):
+    def __init__(self, on_edit_button_clicked):
         super().__init__()
         self.transmitter_settings: list = []
+        self.on_edit_button_clicked = on_edit_button_clicked
 
     def build(self):
         return ft.Container(
@@ -58,8 +59,7 @@ class TransmitterContainer(ft.UserControl):
                     ft.DataCell(
                         ft.ElevatedButton(
                             text="編集",
-                            # on_click= partialやクロージャを
-                            # 使った関数である必要があるかも?
+                            on_click= self.on_edit_button_clicked
                         )
                     ),
                 ]


### PR DESCRIPTION
dialogは`page.dialog`というpageのプロパティに`ft.Dialog`のインスタンスオブジェクトを代入、`page.dialog.open=True`とすることで表示できるらしい。`page`はclass `app`の`main()`の中にしかないので、`main()`の中にdialogを定義しました