### PR TITLE
duplicator.settings に設定管理させる設計へ寄せる

### DIFF
--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -32,24 +32,15 @@ class Duplicator:
         self.transmitter = OSCTransmitter(self.queue)
         self.is_duplicate = False
 
-    def start_duplicate(self, receive_port, transmit_port_settings):
+    def start_duplicate(self) -> None:
         """
-        On start button pushed
-
-        Attribute
-        ---------
-        receive_port: int
-            OSCReceiverのポート
-        transmit_port_settings: list[TransmitPortSettings]
-            OSCTransmitterのための設定
+        startボタンが押されたときに呼び出される
         """
-        self.__update_settings(receive_port, transmit_port_settings)
-
         self.receiver = OSCReceiver(self.settings.receive_port, self.queue)
 
-        transmit_ports = self.settings.get_transmit_ports()
-        for port in transmit_ports:
-            self.transmitter.add_destination_port(port)
+        self.transmitter.update_transmit_port(
+            self.settings.get_transmit_ports()
+        )
 
         self.receiver.start()
         self.transmitter.start()
@@ -66,18 +57,6 @@ class Duplicator:
         self.transmitter.pause()
 
         self.is_duplicate = False
-
-    def __update_settings(self, receive_port, transmit_port_settings):
-        """
-        Parameters
-        ---------
-        receive_port: int
-            OSCReceiverのポート
-        transmit_port_settings: list[TransmitPortSettings]
-            OSCTransmitterのための設定
-        """
-        self.settings.update_receive_port_setting(receive_port)
-        self.settings.update_transmit_port_settings(transmit_port_settings)
 
     def save_settings(self):
         self.settings.save_json(Duplicator.FILE_PATH)

--- a/oscduplicator/osc_transmitter.py
+++ b/oscduplicator/osc_transmitter.py
@@ -24,8 +24,10 @@ class OSCTransmitter:
     def pause(self) -> None:
         self._running = False
 
-    def update(self,
-               transmit_port_settings: list[TransmitPortSetting]) -> None:
+    def update_transmit_port(
+            self,
+            transmit_port_settings: list[TransmitPortSetting],
+            ) -> None:
         with self._clients_lock:
             self._clients.clear()
             for setting in transmit_port_settings:

--- a/oscduplicator/osc_transmitter.py
+++ b/oscduplicator/osc_transmitter.py
@@ -14,7 +14,6 @@ class OSCTransmitter:
         self._q = q
         self._clients: dict[int, SimpleUDPClient] = {}
         self._clients_lock = Lock()
-        self._transmit_port_settings: list[TransmitPortSetting] = []
         self._thread = Thread(target=self._loop, daemon=True)
         self._thread.start()
         self._running = False
@@ -33,10 +32,6 @@ class OSCTransmitter:
                 self._clients[setting.port] = SimpleUDPClient(
                     OSCTransmitter.ADDRESS, setting.port
                 )
-            self._transmit_port_settings = transmit_port_settings
-
-    def get_transmit_port_settings(self) -> list[TransmitPortSetting]:
-        return self._transmit_port_settings
 
     def _loop(self) -> None:
         while True:

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+from oscduplicator.duplicator import Duplicator
+
+
+def test_stop_duplicate():
+    duplicator = Duplicator()
+    duplicator.receiver = receiver_mock = Mock()
+    duplicator.transmitter = transmitter_mock = Mock()
+
+    duplicator.stop_duplicate()
+
+    receiver_mock.stop.assert_called_once()
+    transmitter_mock.pause.assert_called_once()

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -1,6 +1,13 @@
 from unittest.mock import Mock
 
+import pytest
+
 from oscduplicator.duplicator import Duplicator
+
+
+@pytest.mark.skip(reason="テスト未実装")  # TODO テストしやすい実装に書き換えてからテストを追加する
+def test_start_duplicate():
+    pass
 
 
 def test_stop_duplicate():
@@ -12,3 +19,8 @@ def test_stop_duplicate():
 
     receiver_mock.stop.assert_called_once()
     transmitter_mock.pause.assert_called_once()
+
+
+@pytest.mark.skip(reason="テスト未実装")  # TODO テストしやすい実装に書き換えてからテストを追加する
+def test_save_settings():
+    pass

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -39,12 +39,12 @@ def test_pause():
     assert transmitter._running is False
 
 
-def test_update():
+def test_update_transmit_port():
     transmitter = OSCTransmitter(Queue())
     transmitter._clients[1234] = Mock()
     assert len(transmitter._clients) == 1
 
-    transmitter.update(
+    transmitter.update_transmit_port(
         [
             TransmitPortSetting("test0", 9000, True),
             TransmitPortSetting("test1", 9001, True),

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from oscduplicator.osc_receiver import OSCMessage
 from oscduplicator.osc_transmitter import OSCTransmitter
+from oscduplicator.transmit_port_setting import TransmitPortSetting
 
 
 def test_init():
@@ -38,52 +39,24 @@ def test_pause():
     assert transmitter._running is False
 
 
-def test_add_destination_port():
+def test_update():
     transmitter = OSCTransmitter(Queue())
+    transmitter._clients[1234] = Mock()
 
-    # Add a new port
-    port1 = 8000
-    assert transmitter.add_destination_port(port1) is True
+    transmit_port_settings = [
+        TransmitPortSetting("test0", 9000, True),
+        TransmitPortSetting("test1", 9001, True),
+    ]
 
-    # Add the same port again
-    assert transmitter.add_destination_port(port1) is False
+    transmitter.update(transmit_port_settings)
 
-    # Add a different port
-    port2 = 9000
-    assert transmitter.add_destination_port(port2) is True
-
-    # Check if the clients dictionary is updated correctly
-    assert port1 in transmitter._clients
-    assert port2 in transmitter._clients
     assert len(transmitter._clients) == 2
-
-    # Check if the SimpleUDPClient instances are created correctly
-    assert transmitter._clients[port1]._address == OSCTransmitter.ADDRESS
-    assert transmitter._clients[port1]._port == port1
-    assert transmitter._clients[port2]._address == OSCTransmitter.ADDRESS
-    assert transmitter._clients[port2]._port == port2
+    assert 9000 in transmitter._clients
+    assert 9001 in transmitter._clients
 
 
-def test_remove_destination_port():
+def test_get_transmit_port_settings():
     transmitter = OSCTransmitter(Queue())
-
-    # Add ports
-    port1 = 8000
-    port2 = 9000
-    transmitter.add_destination_port(port1)
-    transmitter.add_destination_port(port2)
-    assert len(transmitter._clients) == 2
-
-    # Remove a port that exists
-    transmitter.remove_destination_port(port1)
-    assert port1 not in transmitter._clients
-    assert len(transmitter._clients) == 1
-
-    # Remove a port that doesn't exist
-    non_existing_port = 10000
-    #   Should not raise an error
-    transmitter.remove_destination_port(non_existing_port)
-    assert len(transmitter._clients) == 1
-
-    # Check if the other port still exists
-    assert port2 in transmitter._clients
+    transmit_port_settings = []
+    transmitter._transmit_port_settings = transmit_port_settings
+    assert transmitter.get_transmit_port_settings() is transmit_port_settings

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -42,21 +42,17 @@ def test_pause():
 def test_update():
     transmitter = OSCTransmitter(Queue())
     transmitter._clients[1234] = Mock()
+    assert len(transmitter._clients) == 1
 
-    transmit_port_settings = [
-        TransmitPortSetting("test0", 9000, True),
-        TransmitPortSetting("test1", 9001, True),
-    ]
+    transmitter.update(
+        [
+            TransmitPortSetting("test0", 9000, True),
+            TransmitPortSetting("test1", 9001, True),
+        ]
+    )
 
-    transmitter.update(transmit_port_settings)
-
+    # The old client should be removed.
+    # The new clients should be added.
     assert len(transmitter._clients) == 2
     assert 9000 in transmitter._clients
     assert 9001 in transmitter._clients
-
-
-def test_get_transmit_port_settings():
-    transmitter = OSCTransmitter(Queue())
-    transmit_port_settings = []
-    transmitter._transmit_port_settings = transmit_port_settings
-    assert transmitter.get_transmit_port_settings() is transmit_port_settings


### PR DESCRIPTION
設定の原本を `duplicator.settings` とする設計へ寄せていくため、
* startボタンクリック時の設定受け渡しを廃止します。
* Transmitterへの設定適用は、 `list[TransmitPortSetting]` を読み込ませる形式とします。