### PR TITLE
Settingsの改修

### DIFF
--- a/oscduplicator/settings.py
+++ b/oscduplicator/settings.py
@@ -20,8 +20,12 @@ class Settings:
     FILE_PATH = Path("./oscduplicator/settings.json")
 
     def __init__(self) -> None:
-        self.receive_port: int | None = None
+        self._receive_port: int | None = None
         self.transmit_port_settings: list[TransmitPortSetting] = []
+
+    @property
+    def receive_port(self) -> int | None:
+        return self._receive_port
 
     def load_json(self) -> None:
         """
@@ -30,8 +34,8 @@ class Settings:
         with Settings.FILE_PATH.open("r", encoding="UTF-8") as f:
             data = json.load(f)
 
-        self.receive_port = data["receive"]["port"]
         self.transmit_port_settings.clear()
+        self.update_receive_port_setting(data["receive"]["port"])
         for element in data["transmit"]:
             self.add_transmit_port_setting(
                 name=element["name"],
@@ -48,8 +52,13 @@ class Settings:
         with Settings.FILE_PATH.open("w", encoding="UTF-8") as f:
             json.dump(save_data, f, indent=4, ensure_ascii=False)
 
-    def update_receive_port_setting(self, port: int):
-        self.receive_port = port
+    def update_receive_port_setting(self, port: int) -> bool:
+        if self.receive_port == port:
+            return False
+        if any(s.port == port for s in self.transmit_port_settings):
+            return False
+        self._receive_port = port
+        return True
 
     def add_transmit_port_setting(self,
                                   name: str, port: int, enabled: bool) -> bool:

--- a/oscduplicator/settings.py
+++ b/oscduplicator/settings.py
@@ -1,6 +1,6 @@
+from dataclasses import asdict
 import json
 from pathlib import Path
-from dataclasses import asdict
 
 from oscduplicator.transmit_port_setting import TransmitPortSetting
 
@@ -33,12 +33,10 @@ class Settings:
         self.receive_port = data["receive"]["port"]
         self.transmit_port_settings.clear()
         for element in data["transmit"]:
-            self.transmit_port_settings.append(
-                TransmitPortSetting(
-                    name=element["name"],
-                    port=element["port"],
-                    enabled=element["enabled"],
-                )
+            self.add_transmit_port_setting(
+                name=element["name"],
+                port=element["port"],
+                enabled=element["enabled"],
             )
 
     def save_json(self):
@@ -52,6 +50,17 @@ class Settings:
 
     def update_receive_port_setting(self, port: int):
         self.receive_port = port
+
+    def add_transmit_port_setting(self,
+                                  name: str, port: int, enabled: bool) -> bool:
+        if self.receive_port == port:
+            return False
+        if any(s.port == port for s in self.transmit_port_settings):
+            return False
+        self.transmit_port_settings.append(
+            TransmitPortSetting(name, port, enabled)
+        )
+        return True
 
     def remove_transmit_port_setting(self, port: int) -> None:
         for i in reversed(range(len(self.transmit_port_settings))):

--- a/oscduplicator/settings.py
+++ b/oscduplicator/settings.py
@@ -53,11 +53,6 @@ class Settings:
     def update_receive_port_setting(self, port: int):
         self.receive_port = port
 
-    def update_transmit_port_settings(
-        self, transmit_port_settings: list[TransmitPortSetting]
-    ):
-        self.transmit_port_settings = transmit_port_settings
-
     def remove_transmit_port_setting(self, port: int) -> None:
         for i in reversed(range(len(self.transmit_port_settings))):
             if self.transmit_port_settings[i].port == port:

--- a/oscduplicator/settings.py
+++ b/oscduplicator/settings.py
@@ -42,14 +42,9 @@ class Settings:
             )
 
     def save_json(self):
-        """
-        jsonファイルに設定を保存する
-        """
-        l_dict: list[dict] = [asdict(d) for d in self.transmit_port_settings]
-
-        save_data: dict = {
+        save_data = {
             "receive": {"port": self.receive_port},
-            "transmit": l_dict,
+            "transmit": list(map(asdict, self.transmit_port_settings)),
         }
 
         with Settings.FILE_PATH.open("w", encoding="UTF-8") as f:

--- a/oscduplicator/settings.py
+++ b/oscduplicator/settings.py
@@ -63,18 +63,17 @@ class Settings:
     ):
         self.transmit_port_settings = transmit_port_settings
 
-    def remove_transmit_port_setting(self, port: int):
-        for i in range(len(self.transmit_port_settings)):
-            if self.transmit_port_settings[i][0] == port:
+    def remove_transmit_port_setting(self, port: int) -> None:
+        for i in reversed(range(len(self.transmit_port_settings))):
+            if self.transmit_port_settings[i].port == port:
                 del self.transmit_port_settings[i]
-                return
 
-    def enable_transmit_port(self, port: int):
-        for i in range(len(self.transmit_port_settings)):
-            if self.transmit_port_settings[i][0] == port:
-                self.transmit_port_settings[i][2] = True
+    def enable_transmit_port(self, port: int) -> None:
+        for setting in self.transmit_port_settings:
+            if setting.port == port:
+                setting.enabled = True
 
-    def disable_transmit_port(self, port: int):
-        for i in range(len(self.transmit_port_settings)):
-            if self.transmit_port_settings[i][0] == port:
-                self.transmit_port_settings[i][2] = False
+    def disable_transmit_port(self, port: int) -> None:
+        for setting in self.transmit_port_settings:
+            if setting.port == port:
+                setting.enabled = False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -83,9 +83,29 @@ def test_save_json():
 
 def test_update_receive_port_setting():
     settings = Settings()
-    settings.receive_port = 9000
-    settings.update_receive_port_setting(9001)
-    assert settings.receive_port == 9001
+    settings.receive_port = 9001
+    settings.update_receive_port_setting(9002)
+    assert settings.receive_port == 9002
+
+
+def test_add_transmit_port_setting():
+    settings = Settings()
+    settings.receive_port = 9001
+    settings.transmit_port_settings = [
+        TransmitPortSetting("app_a", 9002, True),
+        TransmitPortSetting("app_b", 9003, False),
+    ]
+
+    assert settings.add_transmit_port_setting("app_c", 9004, True) is True
+    assert len(settings.transmit_port_settings) == 3
+
+    # 重複するポート番号を指定した場合は追加しない
+    assert settings.add_transmit_port_setting("app_d", 9002, True) is False
+    assert len(settings.transmit_port_settings) == 3
+
+    # 受信と同一ポート番号を指定した場合は追加しない
+    assert settings.add_transmit_port_setting("app_e", 9001, True) is False
+    assert len(settings.transmit_port_settings) == 3
 
 
 def test_remove_transmit_port_setting():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -50,7 +50,7 @@ def test_save_json():
     mock_path.open.return_value.__enter__.return_value = string_buffer
 
     settings = Settings()
-    settings.receive_port = 9001
+    settings.update_receive_port_setting(9001)
     settings.transmit_port_settings = [
         TransmitPortSetting("app_a", 9002, True),
         TransmitPortSetting("app_b", 9003, False),
@@ -83,14 +83,28 @@ def test_save_json():
 
 def test_update_receive_port_setting():
     settings = Settings()
-    settings.receive_port = 9001
-    settings.update_receive_port_setting(9002)
-    assert settings.receive_port == 9002
+    settings.update_receive_port_setting(9001)
+
+    settings.transmit_port_settings = [
+        TransmitPortSetting("app_a", 9002, True),
+        TransmitPortSetting("app_b", 9003, False),
+    ]
+
+    assert settings.update_receive_port_setting(9004) is True
+    assert settings.receive_port == 9004
+
+    # 同一ポート番号を指定した場合は更新しない
+    assert settings.update_receive_port_setting(9004) is False
+    assert settings.receive_port == 9004
+
+    # 送信先に含まれるポート番号を指定した場合は更新しない
+    assert settings.update_receive_port_setting(9003) is False
+    assert settings.receive_port == 9004
 
 
 def test_add_transmit_port_setting():
     settings = Settings()
-    settings.receive_port = 9001
+    settings.update_receive_port_setting(9001)
     settings.transmit_port_settings = [
         TransmitPortSetting("app_a", 9002, True),
         TransmitPortSetting("app_b", 9003, False),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,9 @@
+from io import StringIO
 import json
-from unittest.mock import Mock, mock_open
+from unittest.mock import MagicMock, Mock, mock_open
 
 from oscduplicator.settings import Settings
+from oscduplicator.transmit_port_setting import TransmitPortSetting
 
 
 def test_load_json():
@@ -39,4 +41,91 @@ def test_load_json():
     assert settings.transmit_port_settings[0].enabled is True
     assert settings.transmit_port_settings[1].name == "app_b"
     assert settings.transmit_port_settings[1].port == 9003
+    assert settings.transmit_port_settings[1].enabled is False
+
+
+def test_save_json():
+    Settings.FILE_PATH = mock_path = MagicMock()
+    string_buffer = StringIO()
+    mock_path.open.return_value.__enter__.return_value = string_buffer
+
+    settings = Settings()
+    settings.receive_port = 9001
+    settings.transmit_port_settings = [
+        TransmitPortSetting("app_a", 9002, True),
+        TransmitPortSetting("app_b", 9003, False),
+    ]
+
+    settings.save_json()
+
+    assert string_buffer.getvalue() == json.dumps(
+        {
+            "receive": {
+                "port": 9001,
+            },
+            "transmit": [
+                {
+                    "name": "app_a",
+                    "port": 9002,
+                    "enabled": True,
+                },
+                {
+                    "name": "app_b",
+                    "port": 9003,
+                    "enabled": False,
+                },
+            ],
+        },
+        indent=4,
+        ensure_ascii=False,
+    )
+
+
+def test_update_receive_port_setting():
+    settings = Settings()
+    settings.receive_port = 9000
+    settings.update_receive_port_setting(9001)
+    assert settings.receive_port == 9001
+
+
+def test_remove_transmit_port_setting():
+    settings = Settings()
+    settings.transmit_port_settings = [
+        TransmitPortSetting("app_a", 9002, True),
+        TransmitPortSetting("app_b", 9003, False),
+    ]
+
+    settings.remove_transmit_port_setting(9002)
+
+    assert len(settings.transmit_port_settings) == 1
+    assert settings.transmit_port_settings[0].name == "app_b"
+
+
+def test_enable_transmit_port():
+    settings = Settings()
+    settings.transmit_port_settings = [
+        TransmitPortSetting("app_a", 9002, True),
+        TransmitPortSetting("app_b", 9003, False),
+    ]
+
+    settings.enable_transmit_port(9003)
+    assert settings.transmit_port_settings[1].enabled is True
+
+    # 有効なポートを指定した場合は何もしない
+    settings.enable_transmit_port(9002)
+    assert settings.transmit_port_settings[0].enabled is True
+
+
+def test_disable_transmit_port():
+    settings = Settings()
+    settings.transmit_port_settings = [
+        TransmitPortSetting("app_a", 9002, True),
+        TransmitPortSetting("app_b", 9003, False),
+    ]
+
+    settings.disable_transmit_port(9002)
+    assert settings.transmit_port_settings[0].enabled is False
+
+    # 無効なポートを指定した場合は何もしない
+    settings.disable_transmit_port(9003)
     assert settings.transmit_port_settings[1].enabled is False


### PR DESCRIPTION
#22 の続きです。

* すべてのメソッドにテストを追加
* `save_json` の実装を簡潔に
* 未使用のメソッドを削除
* 送信先ポートの追加を実装
* 追加・変更時、成否をboolで返すように