### PR TITLE
Duplicatorの改修

### DIFF
--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -26,7 +26,7 @@ class Duplicator:
         self.settings = Settings()
         self.settings.load_json()
         self.queue = Queue()
-        self.receiver: OSCReceiver | None = None
+        self.receiver = OSCReceiver(self.queue)
         self.transmitter = OSCTransmitter(self.queue)
         self.is_duplicate = False
 
@@ -34,8 +34,6 @@ class Duplicator:
         """
         startボタンが押されたときに呼び出される
         """
-        self.receiver = OSCReceiver(self.settings.receive_port, self.queue)
-
         self.transmitter.update_transmit_port(
             self.settings.transmit_port_settings,
         )
@@ -49,9 +47,7 @@ class Duplicator:
         """
         On stop button pushed
         """
-        if self.receiver:
-            self.receiver.pause()
-
+        self.receiver.pause()
         self.transmitter.pause()
 
         self.is_duplicate = False

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -24,11 +24,17 @@ class Duplicator:
 
     def __init__(self) -> None:
         self.settings = Settings()
-        self.settings.load_json()
         self.queue = Queue()
         self.receiver = OSCReceiver(self.queue)
         self.transmitter = OSCTransmitter(self.queue)
         self.is_duplicate = False
+
+    def load_settings(self) -> None:
+        self.settings.load_json()
+        self.receiver.update_receive_port(self.settings.receive_port_setting)
+        self.transmitter.update_transmit_port(
+            self.settings.transmit_port_settings
+        )
 
     def start_duplicate(self) -> None:
         """

--- a/oscduplicator/duplicator.py
+++ b/oscduplicator/duplicator.py
@@ -34,10 +34,6 @@ class Duplicator:
         """
         startボタンが押されたときに呼び出される
         """
-        self.transmitter.update_transmit_port(
-            self.settings.transmit_port_settings,
-        )
-
         self.receiver.start()
         self.transmitter.start()
 

--- a/oscduplicator/gui/app.py
+++ b/oscduplicator/gui/app.py
@@ -16,6 +16,7 @@ class App:
         page.window_width, page.window_height = 600, 800
 
         self.duplicator = Duplicator()
+        self.duplicator.load_settings()
 
         self.header = Header(self.duplicator)
         self.receiver_container = ReceiverContainer(self.duplicator)  # ポートは仮

--- a/oscduplicator/osc_receiver.py
+++ b/oscduplicator/osc_receiver.py
@@ -27,8 +27,8 @@ class OSCReceiver:
         受信したOSC messageを格納するキュー
     """
 
-    def __init__(self, receive_port: int, message_queue: Queue) -> None:
-        self.receive_port: int = receive_port
+    def __init__(self, message_queue: Queue) -> None:
+        self._receive_port: int | None = None
         self._server: BlockingOSCUDPServer | None = None
         self._message_queue = message_queue
 
@@ -37,7 +37,7 @@ class OSCReceiver:
         dispatcher.set_default_handler(self.message_handler)
 
         self._server = BlockingOSCUDPServer(
-            ("127.0.0.1", self.receive_port),
+            ("127.0.0.1", self._receive_port),
             dispatcher,
         )
 
@@ -47,6 +47,12 @@ class OSCReceiver:
     def pause(self):
         if self._server:
             self._server.shutdown()
+
+    def update_receive_port(self, receive_port: int):
+        self._receive_port = receive_port
+        if self._server:
+            self.pause()
+            self.start()
 
     def message_handler(self, address: str, *args: Any):
         """

--- a/oscduplicator/osc_receiver.py
+++ b/oscduplicator/osc_receiver.py
@@ -32,7 +32,9 @@ class OSCReceiver:
         self._server: BlockingOSCUDPServer | None = None
         self._message_queue = message_queue
 
-    def start(self):
+    def start(self) -> None:
+        if self._server:
+            return
         dispatcher = Dispatcher()
         dispatcher.set_default_handler(self.message_handler)
 

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -1,13 +1,17 @@
 from unittest.mock import Mock
 
-import pytest
-
 from oscduplicator.duplicator import Duplicator
 
 
-@pytest.mark.skip(reason="テスト未実装")  # TODO テストしやすい実装に書き換えてからテストを追加する
 def test_start_duplicate():
-    pass
+    duplicator = Duplicator()
+    duplicator.receiver = receiver_mock = Mock()
+    duplicator.transmitter = transmitter_mock = Mock()
+
+    duplicator.start_duplicate()
+
+    receiver_mock.start.assert_called_once()
+    transmitter_mock.start.assert_called_once()
 
 
 def test_stop_duplicate():
@@ -21,9 +25,13 @@ def test_stop_duplicate():
     transmitter_mock.pause.assert_called_once()
 
 
-@pytest.mark.skip(reason="テスト未実装")  # TODO テストしやすい実装に書き換えてからテストを追加する
 def test_save_settings():
-    pass
+    duplicator = Duplicator()
+    duplicator.settings = settings_mock = Mock()
+
+    duplicator.save_settings()
+
+    settings_mock.save_json.assert_called_once()
 
 
 def test_add_transmit_port():

--- a/tests/test_duplicator.py
+++ b/tests/test_duplicator.py
@@ -3,6 +3,21 @@ from unittest.mock import Mock
 from oscduplicator.duplicator import Duplicator
 
 
+def test_load_settings():
+    duplicator = Duplicator()
+    duplicator.settings = settings_mock = Mock()
+    duplicator.receiver = receiver_mock = Mock()
+    duplicator.transmitter = transmitter_mock = Mock()
+
+    duplicator.load_settings()
+
+    # 設定がロードされること
+    settings_mock.load_json.assert_called_once()
+    # 設定が反映されること
+    receiver_mock.update_receive_port.assert_called_once()
+    transmitter_mock.update_transmit_port.assert_called_once()
+
+
 def test_start_duplicate():
     duplicator = Duplicator()
     duplicator.receiver = receiver_mock = Mock()

--- a/tests/test_osc_receiver.py
+++ b/tests/test_osc_receiver.py
@@ -8,21 +8,13 @@ from pythonosc.udp_client import SimpleUDPClient
 from oscduplicator.osc_receiver import OSCReceiver
 
 
-def test_init():
-    queue = Queue()
-    receiver = OSCReceiver(5000, queue)
-
-    assert receiver.receive_port == 5000
-    assert receiver._server is None
-    assert receiver._message_queue is queue
-
-
 def test_start():
     with socket() as sock:
         sock.bind(("", 0))
         free_port = sock.getsockname()[1]
 
-    receiver = OSCReceiver(free_port, Mock())
+    receiver = OSCReceiver(Mock())
+    receiver._receive_port = free_port
     receiver.message_handler = handler_mock = Mock()
 
     try:
@@ -46,7 +38,7 @@ def test_start():
 
 
 def test_pause():
-    receiver = OSCReceiver(5000, Queue())
+    receiver = OSCReceiver(Queue())
 
     receiver._server = None
     receiver.pause()  # start前に呼ばれてもエラーにならない
@@ -56,9 +48,26 @@ def test_pause():
     mock_server.shutdown.assert_called_once()
 
 
+def test_update_receive_port():
+    receiver = OSCReceiver(Queue())
+    receiver.pause = pause_mock = Mock()
+    receiver.start = start_mock = Mock()
+
+    # start前に呼ばれてもエラーにならない
+    receiver._server = None
+    receiver.update_receive_port(9002)
+    pause_mock.assert_not_called()
+    start_mock.assert_not_called()  # startしない
+
+    receiver._server = Mock()
+    receiver.update_receive_port(9003)
+    pause_mock.assert_called_once()
+    start_mock.assert_called_once()  # 自動的にstartする
+
+
 def test_message_handler():
     queue = Queue()
-    receiver = OSCReceiver(5000, queue)
+    receiver = OSCReceiver(queue)
 
     receiver.message_handler("/test/0", "message")
     osc_message = queue.get_nowait()

--- a/tests/test_osc_receiver.py
+++ b/tests/test_osc_receiver.py
@@ -33,6 +33,11 @@ def test_start():
         udp_client.send_message("/test/2", None)
         sleep(0.1)
         assert handler_mock.call_args[0] == ("/test/2",)
+
+        # start済みの場合は何もしない
+        server = receiver._server
+        receiver.start()
+        assert receiver._server is server  # サーバーが変わらないこと
     finally:
         receiver.pause()
 


### PR DESCRIPTION
* テストしやすくするため、処理を分割した
* OSCReceiver と OSCTransmitter のインターフェースを統一し、扱いやすくした
    * 設定の反映 と 起動・停止 を分けた
* 不足していたテストを追加した